### PR TITLE
Statically link libjq and libonig to the jq NIF shared library

### DIFF
--- a/c_src/Makefile
+++ b/c_src/Makefile
@@ -53,7 +53,7 @@ endif
 
 CFLAGS += -fPIC -I $(ERTS_INCLUDE_DIR) -I $(ERL_INTERFACE_INCLUDE_DIR) -I $(JQ_INCLUDE_DIR)
 CXXFLAGS += -fPIC -I $(ERTS_INCLUDE_DIR) -I $(ERL_INTERFACE_INCLUDE_DIR) -I $(JQ_INCLUDE_DIR)
-LDLIBS += -L $(ERL_INTERFACE_LIB_DIR) -L $(EXT_LIBS) -lei -ljq
+LDLIBS += -L $(ERL_INTERFACE_LIB_DIR) -L $(EXT_LIBS) -lei -l:libjq.a -l:libonig.a
 LDFLAGS += -shared
 
 # Verbosity.
@@ -106,10 +106,10 @@ $(LIBJQ_NAME): $(JQSRC)
 	#ls -lart .libs/ modules/oniguruma/src/.libs/
 	cd $(JQSRC_DIR) && \
 	git submodule update --init && \
-	autoreconf -fi && \
-	./configure --with-oniguruma=builtin --prefix=$(LIBJQ_PREFIX) && \
-	make -C modules/oniguruma/ && \
-	make src/builtin.inc && make libjq.la && \
+	CFLAGS=-fPIC autoreconf -fi && \
+	CFLAGS=-fPIC ./configure --with-oniguruma=builtin --prefix=$(LIBJQ_PREFIX) && \
+	CFLAGS=-fPIC make -C modules/oniguruma/ && \
+	CFLAGS=-fPIC make src/builtin.inc && CFLAGS=-fPIC make libjq.la && \
 	cp .libs/$(LIBJQ) $(PRIV_DIR)/ && \
 	cp modules/oniguruma/src/.libs/$(LIBONIG) $(PRIV_DIR)/ && \
 	mkdir $(EXT_LIBS) && \


### PR DESCRIPTION
Before this commit the jq NIF shared library would fail to load
if one had not set up the shared library path to include a folder
with shared library files for libjq and libonig. For example by
setting an environment variable like this:

export LD_LIBRARY_PATH=/PATH_TO/jq/c_src/ext_libs

This is fixed in this commit by statically linking
libjq and libonig into the jq NIF library.