### PR TITLE
Fix missing package in github action

### DIFF
--- a/.github/workflows/eunit.yaml
+++ b/.github/workflows/eunit.yaml
@@ -13,18 +13,19 @@ jobs:
       fail-fast: false
       matrix:
         erl_otp:
-        - erl23.2.7
-        #- erl22.3.4.13
+          - 23.3.4.9-4
+          - 24.2.1-1
+        elixir:
+          - 1.13.3
         os:
-        - ubuntu20.04
-        - ubuntu18.04
-        - ubuntu16.04
-        - debian10
-        - debian9
-        - centos8
-        - centos7
+          - ubuntu20.04
+          - ubuntu18.04
+          - ubuntu16.04
+          - debian10
+          - debian9
+          - rockylinux8
 
-    container: emqx/build-env:${{ matrix.erl_otp }}-${{ matrix.os }}
+    container: "ghcr.io/emqx/emqx-builder/5.0-9:${{ matrix.elixir }}-${{ matrix.erl_otp }}-${{ matrix.os }}"
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
* It seems like the ubuntu20.04 image don't have flex installed
  which is needed. This is fixed in this commit.

* The CentOS 7 test failed with the error:

  configure.ac:36: error: possibly undefined macro: AM_PROG_LIBTOOL

  It seems like this might be due to an outdated version of
  GNU autotools. I think we can can comment out CentOS 7 for now
  and fix that later if we need to test on CentOS 7.