### PR TITLE
Add scripts for running eunit tests with memory sanitizer etc

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,19 @@ An Erlang NIF for [jq](https://github.com/stedolan/jq).
   3> jq:parse(<<".a|.[]">>, <<"{\"a\": [1,2,3]}">>).
   {ok,[<<"1">>,<<"2">>,<<"3">>]}
   ```
+
+- Test with address sanitizer
+  
+  There are scripts that can help when one wants to run the
+  eunit tests with address sanitizer. Address sanitizer is
+  included in recent versions of gcc and clang.
+  
+  Use the following commands to run the eunit tests with
+  address sanitizer:
+  ```
+  ./test/address_sanitizer_setup.sh 
+  ./test/address_sanitizer_run_eunit.sh
+  ```
+  The "test/address_sanitizer_setup.sh" scripts compiles an
+  erlang VM with address sanitizer support and don't need
+  to be executed every time a change is made to the NIF.

--- a/c_src/Makefile
+++ b/c_src/Makefile
@@ -20,6 +20,15 @@ else
 	LIBONIG := libonig.so
 endif
 
+ifdef JQ_MEMSAN_DEBUG
+	EXTRA_C_FLAGS := -g -O0 $(MEMSAN_FLAGS) -I $(ERL_TOP)/erts/emulator/beam/ -I $(ERL_TOP)/erts/include/x86_64-pc-linux-gnu/
+	MEMSAN_FLAGS := -fno-omit-frame-pointer -fsanitize=address
+	CC := gcc
+else
+	EXTRA_C_FLAGS := -O3
+	MEMSAN_FLAGS := 
+endif
+
 LIBJQ_NAME := $(LIBJQ_DIR)/$(LIBJQ)
 
 ERTS_INCLUDE_DIR ?= $(shell erl -noshell -s init stop -eval "io:format(\"~ts/erts-~ts/include/\", [code:root_dir(), erlang:system_info(version)]).")
@@ -36,25 +45,25 @@ C_SRC_OUTPUT ?= $(PRIV_DIR)/$(PROJECT).so
 
 ifeq ($(UNAME_SYS), Darwin)
 	CC ?= cc
-	CFLAGS ?= -O3 -std=c99 -arch x86_64 -finline-functions -Wall -Wmissing-prototypes
+	CFLAGS ?= $(EXTRA_C_FLAGS) -std=c99 -arch x86_64 -finline-functions -Wall -Wmissing-prototypes
 	CXXFLAGS ?= -O3 -arch x86_64 -finline-functions -Wall
 	LDFLAGS ?= -arch x86_64 -flat_namespace -undefined suppress
 else ifeq ($(UNAME_SYS), FreeBSD)
 	CC ?= cc
-	CFLAGS ?= -O3 -std=c99 -finline-functions -Wall -Wmissing-prototypes
-	CXXFLAGS ?= -O3 -finline-functions -Wall
+	CFLAGS ?= $(EXTRA_C_FLAGS) -std=c99 -finline-functions -Wall -Wmissing-prototypes
+	CXXFLAGS ?= $(EXTRA_C_FLAGS) -finline-functions -Wall
 	LDFLAGS += -Wl,-rpath,$$ORIGIN
 else ifeq ($(UNAME_SYS), Linux)
-	CC ?= gcc
-	CFLAGS ?= -O3 -std=c99 -finline-functions -Wall -Wmissing-prototypes
-	CXXFLAGS ?= -O3 -finline-functions -Wall
+	CC ?= cc
+	CFLAGS ?= $(EXTRA_C_FLAGS) -std=c99 -finline-functions -Wall -Wmissing-prototypes
+	CXXFLAGS ?= $(EXTRA_C_FLAGS) -finline-functions -Wall
 	LDFLAGS += -Wl,-rpath,$$ORIGIN
 endif
 
 CFLAGS += -fPIC -I $(ERTS_INCLUDE_DIR) -I $(ERL_INTERFACE_INCLUDE_DIR) -I $(JQ_INCLUDE_DIR)
 CXXFLAGS += -fPIC -I $(ERTS_INCLUDE_DIR) -I $(ERL_INTERFACE_INCLUDE_DIR) -I $(JQ_INCLUDE_DIR)
 LDLIBS += -L $(ERL_INTERFACE_LIB_DIR) -L $(EXT_LIBS) -lei -l:libjq.a -l:libonig.a
-LDFLAGS += -shared
+LDFLAGS += $(MEMSAN_FLAGS) -shared
 
 # Verbosity.
 
@@ -106,13 +115,13 @@ $(LIBJQ_NAME): $(JQSRC)
 	#ls -lart .libs/ modules/oniguruma/src/.libs/
 	cd $(JQSRC_DIR) && \
 	git submodule update --init && \
-	CFLAGS=-fPIC autoreconf -fi && \
-	CFLAGS=-fPIC ./configure --with-oniguruma=builtin --prefix=$(LIBJQ_PREFIX) && \
-	CFLAGS=-fPIC make -C modules/oniguruma/ && \
-	CFLAGS=-fPIC make src/builtin.inc && CFLAGS=-fPIC make libjq.la && \
+	CFLAGS="-fPIC $(EXTRA_C_FLAGS)" autoreconf -fi && \
+	CFLAGS="-fPIC $(EXTRA_C_FLAGS)" ./configure --with-oniguruma=builtin --prefix=$(LIBJQ_PREFIX) && \
+	CFLAGS="-fPIC $(EXTRA_C_FLAGS)" make -C modules/oniguruma/ && \
+	CFLAGS="-fPIC $(EXTRA_C_FLAGS)" make src/builtin.inc && CFLAGS=-fPIC make libjq.la && \
 	cp .libs/$(LIBJQ) $(PRIV_DIR)/ && \
 	cp modules/oniguruma/src/.libs/$(LIBONIG) $(PRIV_DIR)/ && \
-	mkdir $(EXT_LIBS) && \
+	(mkdir $(EXT_LIBS) || true) && \
 	cp .libs/libjq.* $(EXT_LIBS)/ && \
 	cp modules/oniguruma/src/.libs/libonig.* $(EXT_LIBS)/ && \
 	cd $(C_SRC_DIR)

--- a/c_src/Makefile
+++ b/c_src/Makefile
@@ -21,11 +21,11 @@ else
 endif
 
 ifdef JQ_MEMSAN_DEBUG
-	EXTRA_C_FLAGS := -g -O0 $(MEMSAN_FLAGS) -I $(ERL_TOP)/erts/emulator/beam/ -I $(ERL_TOP)/erts/include/x86_64-pc-linux-gnu/
 	MEMSAN_FLAGS := -fno-omit-frame-pointer -fsanitize=address
+	EXTRA_C_FLAGS := -fPIC -g -O0 $(MEMSAN_FLAGS) -I $(ERL_TOP)/erts/emulator/beam/ -I $(ERL_TOP)/erts/include/x86_64-pc-linux-gnu/
 	CC := clang
 else
-	EXTRA_C_FLAGS := -O3
+	EXTRA_C_FLAGS := -fPIC -O3
 	MEMSAN_FLAGS := 
 endif
 
@@ -60,7 +60,7 @@ else ifeq ($(UNAME_SYS), Linux)
 	LDFLAGS += -Wl,-rpath,$$ORIGIN
 endif
 
-CFLAGS += -fPIC -I $(ERTS_INCLUDE_DIR) -I $(ERL_INTERFACE_INCLUDE_DIR) -I $(JQ_INCLUDE_DIR)
+CFLAGS += -I $(ERTS_INCLUDE_DIR) -I $(ERL_INTERFACE_INCLUDE_DIR) -I $(JQ_INCLUDE_DIR)
 CXXFLAGS += -fPIC -I $(ERTS_INCLUDE_DIR) -I $(ERL_INTERFACE_INCLUDE_DIR) -I $(JQ_INCLUDE_DIR)
 LDLIBS += -L $(ERL_INTERFACE_LIB_DIR) -L $(EXT_LIBS) -lei -l:libjq.a -l:libonig.a
 LDFLAGS += $(MEMSAN_FLAGS) -shared
@@ -115,11 +115,14 @@ $(LIBJQ_NAME): $(JQSRC)
 	#ls -lart .libs/ modules/oniguruma/src/.libs/
 	cd $(JQSRC_DIR) && \
 	git submodule update --init && \
-	CC=$(CC) CFLAGS="-fPIC $(EXTRA_C_FLAGS)" autoreconf -fi && \
-	CC=$(CC) CFLAGS="-fPIC $(EXTRA_C_FLAGS)" ./configure --with-oniguruma=builtin --prefix=$(LIBJQ_PREFIX) CC=$(CC) CFLAGS="-fPIC $(EXTRA_C_FLAGS)" && \
-	CC=$(CC) CFLAGS="-fPIC $(EXTRA_C_FLAGS)" make -C modules/oniguruma/ && \
-	CC=$(CC) CFLAGS="-fPIC $(EXTRA_C_FLAGS)" make src/builtin.inc && \
-	CC=$(CC) CFLAGS="-fPIC $(EXTRA_C_FLAGS)" make libjq.la && \
+	export CC="$(CC)" && \
+	export CFLAGS="$(EXTRA_C_FLAGS)" && \
+	export LDFLAGS="$(MEMSAN_FLAGS)" && \
+	autoreconf -fi && \
+	./configure --with-oniguruma=builtin --prefix=$(LIBJQ_PREFIX) && \
+	make -C modules/oniguruma/ && \
+	make src/builtin.inc && \
+	make libjq.la && \
 	cp .libs/$(LIBJQ) $(PRIV_DIR)/ && \
 	cp modules/oniguruma/src/.libs/$(LIBONIG) $(PRIV_DIR)/ && \
 	(mkdir $(EXT_LIBS) || true) && \

--- a/c_src/Makefile
+++ b/c_src/Makefile
@@ -23,7 +23,7 @@ endif
 ifdef JQ_MEMSAN_DEBUG
 	EXTRA_C_FLAGS := -g -O0 $(MEMSAN_FLAGS) -I $(ERL_TOP)/erts/emulator/beam/ -I $(ERL_TOP)/erts/include/x86_64-pc-linux-gnu/
 	MEMSAN_FLAGS := -fno-omit-frame-pointer -fsanitize=address
-	CC := gcc
+	CC := clang
 else
 	EXTRA_C_FLAGS := -O3
 	MEMSAN_FLAGS := 
@@ -115,10 +115,11 @@ $(LIBJQ_NAME): $(JQSRC)
 	#ls -lart .libs/ modules/oniguruma/src/.libs/
 	cd $(JQSRC_DIR) && \
 	git submodule update --init && \
-	CFLAGS="-fPIC $(EXTRA_C_FLAGS)" autoreconf -fi && \
-	CFLAGS="-fPIC $(EXTRA_C_FLAGS)" ./configure --with-oniguruma=builtin --prefix=$(LIBJQ_PREFIX) && \
-	CFLAGS="-fPIC $(EXTRA_C_FLAGS)" make -C modules/oniguruma/ && \
-	CFLAGS="-fPIC $(EXTRA_C_FLAGS)" make src/builtin.inc && CFLAGS=-fPIC make libjq.la && \
+	CC=$(CC) CFLAGS="-fPIC $(EXTRA_C_FLAGS)" autoreconf -fi && \
+	CC=$(CC) CFLAGS="-fPIC $(EXTRA_C_FLAGS)" ./configure --with-oniguruma=builtin --prefix=$(LIBJQ_PREFIX) CC=$(CC) CFLAGS="-fPIC $(EXTRA_C_FLAGS)" && \
+	CC=$(CC) CFLAGS="-fPIC $(EXTRA_C_FLAGS)" make -C modules/oniguruma/ && \
+	CC=$(CC) CFLAGS="-fPIC $(EXTRA_C_FLAGS)" make src/builtin.inc && \
+	CC=$(CC) CFLAGS="-fPIC $(EXTRA_C_FLAGS)" make libjq.la && \
 	cp .libs/$(LIBJQ) $(PRIV_DIR)/ && \
 	cp modules/oniguruma/src/.libs/$(LIBONIG) $(PRIV_DIR)/ && \
 	(mkdir $(EXT_LIBS) || true) && \

--- a/c_src/enif_jq.c
+++ b/c_src/enif_jq.c
@@ -96,8 +96,7 @@ static ERL_NIF_TERM parse_nif(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[
         ret = JQ_ERROR_PARSE;
         // jv_invalid_get_msg destroys input jv object and returns new jv object
         jv_json_text = jv_invalid_get_msg(jv_json_text);
-        strncpy(err_msg, jv_string_value(jv_json_text),
-            MAX_ERR_MSG_LEN);
+        strncpy(err_msg, jv_string_value(jv_json_text), MAX_ERR_MSG_LEN -1);
         goto out;
     }
     //jv_dump(jv_json_text, dumpopts);

--- a/c_src/enif_jq.c
+++ b/c_src/enif_jq.c
@@ -139,7 +139,7 @@ out:// ----------------------------- release -----------------------------------
     }
     jq_teardown(&jq);
     // jq_next sometimes frees the input json and sometimes not so it is difficult
-    // to keep track of how many copies (ref cnt inc) we have made.S
+    // to keep track of how many copies (ref cnt inc) we have made.
     int ref_cnt = jv_get_refcnt(jv_json_text);
     for(int i = 0; i < ref_cnt; i++) { 
         jv_free(jv_json_text);

--- a/c_src/enif_jq.c
+++ b/c_src/enif_jq.c
@@ -148,7 +148,13 @@ out:// ----------------------------- release -----------------------------------
 }
 
 static ErlNifFunc nif_funcs[] = {
-    {"parse", 2, parse_nif}
+    /*
+       The parse_nif function seems to be very slow.
+       The Erlang VM acts very strangely when it is not scheduled
+       on a dirty scheduler (for example, timer:sleep() suspends
+       for a much longer time than is should).
+    */
+    {"parse", 2, parse_nif, ERL_NIF_DIRTY_JOB_CPU_BOUND}
 };
 
 int upgrade(ErlNifEnv* env, void** priv_data, void** old_priv_data, ERL_NIF_TERM load_info)

--- a/c_src/enif_jq.c
+++ b/c_src/enif_jq.c
@@ -1,20 +1,28 @@
 #include "enif_jq.h"
 
-#define MAX_ERR_MSG_LEN 4096
 #define MAX_JQ_FILTER_LEN 4096
 
+typedef struct {
+    ErlNifEnv* env;
+    ERL_NIF_TERM* error_msg_bin_ptr;
+} NifEnvAndErrBinPtr;
+
+// Forward declaration
+static ERL_NIF_TERM make_error_msg_bin(ErlNifEnv* env, const char* msg);
 
 static void err_callback(void *data, jv err) {
-    char* err_data = data;
+    NifEnvAndErrBinPtr* env_and_msg_bin = data;
+    ErlNifEnv* env = env_and_msg_bin->env; 
+    ERL_NIF_TERM* error_msg_bin_ptr = env_and_msg_bin->error_msg_bin_ptr; 
     if (jv_get_kind(err) != JV_KIND_STRING)
         err = jv_dump_string(err, JV_PRINT_INVALID);
-    snprintf(err_data, MAX_ERR_MSG_LEN, "%s", jv_string_value(err));
+    *error_msg_bin_ptr = make_error_msg_bin(env, jv_string_value(err));
     jv_free(err);
 }
 
 static int process_json(jq_state *jq, jv value,
         ErlNifEnv* env, ERL_NIF_TERM *ret_list, int flags, int dumpopts,
-        char err_msg[MAX_ERR_MSG_LEN]) {
+        ERL_NIF_TERM* error_msg_bin_ptr) {
   int ret = JQ_ERROR_UNKNOWN;
   jq_start(jq, value, flags);
   jv result;
@@ -37,11 +45,16 @@ static int process_json(jq_state *jq, jv value,
     // Uncaught jq exception
     jv msg = jv_invalid_get_msg(jv_copy(result));
     if (jv_get_kind(msg) == JV_KIND_STRING) {
-        snprintf(err_msg, MAX_ERR_MSG_LEN, "jq error: %s\n", jv_string_value(msg));
+        size_t binsz = snprintf(NULL, 0, "jq error: %s\n", jv_string_value(msg));
+        char* bin_data = (char*)enif_make_new_binary(env, binsz, error_msg_bin_ptr);
+        snprintf(bin_data, binsz, "jq error: %s\n", jv_string_value(msg));
     } else {
         msg = jv_dump_string(msg, 0);
-        snprintf(err_msg, MAX_ERR_MSG_LEN, "jq error (not a string): %s\n",
-            jv_string_value(msg));
+        size_t binsz = snprintf(NULL, 0, "jq error (not a string): %s\n",
+                jv_string_value(msg));
+        char* bin_data = (char*)enif_make_new_binary(env, binsz, error_msg_bin_ptr);
+        snprintf(bin_data, binsz, "jq error (not a string): %s\n",
+                jv_string_value(msg));
     }
     ret = JQ_ERROR_PROCESS;
     jv_free(msg);
@@ -50,13 +63,17 @@ static int process_json(jq_state *jq, jv value,
   return ret;
 }
 
-static ERL_NIF_TERM make_error_return(ErlNifEnv* env, int err_no, const char* msg) {
-    const char* err_tag = err_tags[err_no];
+static ERL_NIF_TERM make_error_msg_bin(ErlNifEnv* env, const char* msg) {
     ERL_NIF_TERM err_msg_term;
     int binterm_sz = strlen(msg);
     memcpy(enif_make_new_binary(env, binterm_sz, &err_msg_term), msg, binterm_sz);
+    return err_msg_term;
+}
+
+static ERL_NIF_TERM make_error_return(ErlNifEnv* env, int err_no, ERL_NIF_TERM err_msg_bin) {
+    const char* err_tag = err_tags[err_no];
     return enif_make_tuple2(env, enif_make_atom(env, "error"),
-             enif_make_tuple2(env, enif_make_atom(env, err_tag), err_msg_term));
+             enif_make_tuple2(env, enif_make_atom(env, err_tag), err_msg_bin));
 }
 
 static ERL_NIF_TERM make_ok_return(ErlNifEnv* env, ERL_NIF_TERM result) {
@@ -65,30 +82,33 @@ static ERL_NIF_TERM make_ok_return(ErlNifEnv* env, ERL_NIF_TERM result) {
 
 static ERL_NIF_TERM parse_nif(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
 {
-    char err_msg[MAX_ERR_MSG_LEN];
+    ERL_NIF_TERM error_msg_bin; 
     char jv_filter[MAX_JQ_FILTER_LEN] = {0};
     // ----------------------------- init --------------------------------------
     jq_state *jq = NULL;
     int ret = JQ_ERROR_UNKNOWN;
     ERL_NIF_TERM ret_term;
-    memset(err_msg, 0, MAX_ERR_MSG_LEN * sizeof(char));
     int dumpopts = 512; // JV_PRINT_SPACE1
     jq = jq_init();
     if (jq == NULL) {
         ret = JQ_ERROR_SYSTEM;
-        strcpy(err_msg, "jq_init: malloc error");
+        error_msg_bin = make_error_msg_bin(env, "jq_init: malloc error");
         goto out;
     }
-    jq_set_error_cb(jq, err_callback, err_msg);
+    NifEnvAndErrBinPtr env_and_msg_bin = {
+        .env = env,
+        .error_msg_bin_ptr = &error_msg_bin
+    };
+    jq_set_error_cb(jq, err_callback, &env_and_msg_bin);
 
     // --------------------------- read args -----------------------------------
     ErlNifBinary erl_jq_filter, erl_json_text;
     if (!enif_inspect_binary(env, argv[0], &erl_jq_filter) ||
         !enif_inspect_binary(env, argv[1], &erl_json_text)) {
         ret = JQ_ERROR_BADARG;
-        strcpy(err_msg, "invalid input or filter");
+        error_msg_bin = make_error_msg_bin(env, "jq_init: malloc error");
         goto out;
-	}
+    }
 
     // ------------------------- parse input json -----------------------------
     jv jv_json_text = jv_parse_sized((const char*)erl_json_text.data, erl_json_text.size);
@@ -96,7 +116,7 @@ static ERL_NIF_TERM parse_nif(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[
         ret = JQ_ERROR_PARSE;
         // jv_invalid_get_msg destroys input jv object and returns new jv object
         jv_json_text = jv_invalid_get_msg(jv_json_text);
-        strncpy(err_msg, jv_string_value(jv_json_text), MAX_ERR_MSG_LEN -1);
+        error_msg_bin = make_error_msg_bin(env, jv_string_value(jv_json_text));
         goto out;
     }
     //jv_dump(jv_json_text, dumpopts);
@@ -104,20 +124,20 @@ static ERL_NIF_TERM parse_nif(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[
     // -------------------------- compile filter -------------------------------
     if (erl_jq_filter.size >= MAX_JQ_FILTER_LEN) {
         ret = JQ_ERROR_SYSTEM;
-        strcpy(err_msg, "jq filter is too long");
+        error_msg_bin = make_error_msg_bin(env, "jq filter is too long");
         goto out;
     }
     strncpy(jv_filter, (const char*)erl_jq_filter.data, erl_jq_filter.size);
     if (!jq_compile(jq, jv_filter)) {
         ret = JQ_ERROR_COMPILE;
-        strcpy(err_msg, "compile jq filter failed");
+        error_msg_bin = make_error_msg_bin(env, "compile jq filter failed");
         goto out;
     }
 
     // ---------------------- process json text --------------------------------
     ERL_NIF_TERM ret_list = enif_make_list(env, 0);
     /*TODO: process_raw(jq, jv_json_text, &result, 0, dumpopts)*/
-    ret = process_json(jq, jv_copy(jv_json_text), env, &ret_list, 0, dumpopts, err_msg);
+    ret = process_json(jq, jv_copy(jv_json_text), env, &ret_list, 0, dumpopts, &error_msg_bin);
 
 out:// ----------------------------- release -----------------------------------
     switch (ret) {
@@ -129,7 +149,7 @@ out:// ----------------------------- release -----------------------------------
         case JQ_ERROR_COMPILE:
         case JQ_ERROR_PARSE:
         case JQ_ERROR_PROCESS: {
-            ret_term = make_error_return(env, ret, err_msg);
+            ret_term = make_error_return(env, ret, error_msg_bin);
             break;
         }
         case JQ_OK: {

--- a/c_src/enif_jq.c
+++ b/c_src/enif_jq.c
@@ -3,7 +3,6 @@
 #define MAX_ERR_MSG_LEN 4096
 #define MAX_JQ_FILTER_LEN 4096
 
-char err_msg[MAX_ERR_MSG_LEN];
 
 static void err_callback(void *data, jv err) {
     char* err_data = data;
@@ -14,7 +13,8 @@ static void err_callback(void *data, jv err) {
 }
 
 static int process_json(jq_state *jq, jv value,
-        ErlNifEnv* env, ERL_NIF_TERM *ret_list, int flags, int dumpopts) {
+        ErlNifEnv* env, ERL_NIF_TERM *ret_list, int flags, int dumpopts,
+        char err_msg[MAX_ERR_MSG_LEN]) {
   int ret = JQ_ERROR_UNKNOWN;
   jq_start(jq, value, flags);
   jv result;
@@ -65,6 +65,7 @@ static ERL_NIF_TERM make_ok_return(ErlNifEnv* env, ERL_NIF_TERM result) {
 
 static ERL_NIF_TERM parse_nif(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
 {
+    char err_msg[MAX_ERR_MSG_LEN];
     char jv_filter[MAX_JQ_FILTER_LEN] = {0};
     // ----------------------------- init --------------------------------------
     jq_state *jq = NULL;
@@ -117,7 +118,7 @@ static ERL_NIF_TERM parse_nif(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[
     // ---------------------- process json text --------------------------------
     ERL_NIF_TERM ret_list = enif_make_list(env, 0);
     /*TODO: process_raw(jq, jv_json_text, &result, 0, dumpopts)*/
-    ret = process_json(jq, jv_copy(jv_json_text), env, &ret_list, 0, dumpopts);
+    ret = process_json(jq, jv_copy(jv_json_text), env, &ret_list, 0, dumpopts, err_msg);
 
 out:// ----------------------------- release -----------------------------------
     switch (ret) {

--- a/test/address_sanitizer_run_eunit.sh
+++ b/test/address_sanitizer_run_eunit.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+
+echo "============================================"
+echo "Note that the \"test/address_sanitizer_setup.sh\" has to run"
+echo "successfully at least once before this script will work."
+echo "============================================"
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+OLD_DIR=`pwd`
+
+cd "$SCRIPT_DIR/../otp"
+
+
+export ERL_TOP=`pwd`
+export PATH=$ERL_TOP/bin:$PATH
+    
+echo "Changed ERL_TOP ($ERL_TOP) and PATH"
+
+cerl -asan -eval "erlang:halt()"
+
+cd "$SCRIPT_DIR/.."
+
+(JQ_MEMSAN_DEBUG=1 rebar3 eunit ; true)
+echo "The \"ASan runtime does not come first...\" error above can be ignored"
+
+
+echo "============================================"
+echo "Running the eunit test with address sanitizer"
+echo "============================================"
+
+
+rm -rf asan_logs
+
+export ASAN_LOG_DIR=`pwd`/asan_logs
+
+mkdir "$ASAN_LOG_DIR"
+
+cerl -asan -pa _build/test/lib/jq/test/ -pa _build/test/lib/jq/ebin/ -eval "jq_tests:test(),erlang:halt()" 
+
+echo "============================================"
+echo "The address sanitizer log (located in \"$ASAN_LOG_DIR\") will now be printed:"
+echo "============================================"
+
+cat "$ASAN_LOG_DIR/`ls "$ASAN_LOG_DIR"`"
+
+cd "$OLD_DIR"

--- a/test/address_sanitizer_run_eunit.sh
+++ b/test/address_sanitizer_run_eunit.sh
@@ -1,5 +1,4 @@
-#!/bin/bash
-
+#!/usr/bin/env bash
 
 echo "============================================"
 echo "Note that the \"test/address_sanitizer_setup.sh\" has to run"
@@ -7,32 +6,24 @@ echo "successfully at least once before this script will work."
 echo "============================================"
 
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
-OLD_DIR=`pwd`
 
 cd "$SCRIPT_DIR/../otp"
-
 
 export ERL_TOP=`pwd`
 export PATH=$ERL_TOP/bin:$PATH
     
-echo "Changed ERL_TOP ($ERL_TOP) and PATH"
-
-cerl -asan -eval "erlang:halt()"
-
 cd "$SCRIPT_DIR/.."
 
-(JQ_MEMSAN_DEBUG=1 rebar3 eunit ; true)
+(JQ_MEMSAN_DEBUG=1 rebar3 eunit || true)
 echo "The asan error above can most likely be ignored if everything below runs without problems"
-
 
 echo "============================================"
 echo "Running the eunit test with address sanitizer"
 echo "============================================"
 
-
-rm -rf asan_logs
-
 export ASAN_LOG_DIR=`pwd`/asan_logs
+
+(rm -rf "$ASAN_LOG_DIR" || true)
 
 mkdir "$ASAN_LOG_DIR"
 
@@ -48,4 +39,3 @@ echo "============================================"
 
 cat "$ASAN_LOG_DIR/`ls "$ASAN_LOG_DIR"`"
 
-cd "$OLD_DIR"

--- a/test/address_sanitizer_run_eunit.sh
+++ b/test/address_sanitizer_run_eunit.sh
@@ -36,7 +36,11 @@ export ASAN_LOG_DIR=`pwd`/asan_logs
 
 mkdir "$ASAN_LOG_DIR"
 
-cerl -asan -pa _build/test/lib/jq/test/ -pa _build/test/lib/jq/ebin/ -eval "jq_tests:test(),erlang:halt()" 
+# ASAN_OPTIONS=intercept_tls_get_addr=0 is a workaround for a bug in address sanitizer that we hit
+# https://github.com/google/sanitizers/issues/1322
+# https://github.com/neovim/neovim/pull/17213
+
+ASAN_OPTIONS=intercept_tls_get_addr=0 cerl -asan -pa _build/test/lib/jq/test/ -pa _build/test/lib/jq/ebin/ -eval "jq_tests:test(),erlang:halt()" 
 
 echo "============================================"
 echo "The address sanitizer log (located in \"$ASAN_LOG_DIR\") will now be printed:"

--- a/test/address_sanitizer_run_eunit.sh
+++ b/test/address_sanitizer_run_eunit.sh
@@ -22,7 +22,7 @@ cerl -asan -eval "erlang:halt()"
 cd "$SCRIPT_DIR/.."
 
 (JQ_MEMSAN_DEBUG=1 rebar3 eunit ; true)
-echo "The \"ASan runtime does not come first...\" error above can be ignored"
+echo "The asan error above can most likely be ignored if everything below runs without problems"
 
 
 echo "============================================"

--- a/test/address_sanitizer_setup.sh
+++ b/test/address_sanitizer_setup.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+OLD_DIR=`pwd`
+
+cd "$SCRIPT_DIR/.."
+
+if [ ! -d otp ]
+then
+    git clone git@github.com:erlang/otp.git
+
+    cd otp
+
+    export ERL_TOP=`pwd`
+    export PATH=$ERL_TOP/bin:$PATH
+    
+    echo "Changed ERL_TOP and PATH"
+
+
+    git checkout OTP-24.2.1
+
+    LAST_COMMIT_SHA=$(git rev-parse HEAD)
+
+    if [ ${LAST_COMMIT_SHA} != 7bf7f01683acf9b8f09bd8c7331854a9abc17f7d ]
+    then
+        echo "Unexpected commit SHA"
+        exit 1
+    fi
+
+    ./configure
+
+    make -j
+
+    cd erts/emulator
+
+    make asan
+fi
+
+cd "$SCRIPT_DIR/../otp"
+
+export ERL_TOP=`pwd`
+export PATH=$ERL_TOP/bin:$PATH
+
+echo Changed ERL_TOP and PATH
+
+cd "$SCRIPT_DIR/.."
+
+rm -rf c_src/jqc
+rm -rf c_src/ext_libs
+
+rebar3 clean
+
+(mkdir c_src/ext_libs || true)
+
+cp "$ERL_TOP/lib/erl_interface/obj/x86_64-pc-linux-gnu/libei.a" c_src/ext_libs/
+
+JQ_MEMSAN_DEBUG=1 rebar3 compile
+
+cd "$OLD_DIR"
+
+echo "======================================================================================="
+echo "Things are now set up to run tests with address sanitizer (if nothing has gone wrong)"
+echo
+echo "The following have been compiled with address sanitizer :"
+echo
+echo "1. An Erlang VM (located in jq/otp)"
+echo "2. The jq library"
+echo "3. The jq NIF library"
+echo
+echo "You can now run the eunit test with address sanitizer  with the command:"
+echo "./test/address_sanitizer_run_eunit.sh"
+echo
+echo "To run or compile the jq NIF library without address sanitizer  again, you"
+echo "have to first run \"rebar3 clean\""
+echo "======================================================================================="

--- a/test/address_sanitizer_setup.sh
+++ b/test/address_sanitizer_setup.sh
@@ -1,7 +1,6 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
-OLD_DIR=`pwd`
 
 cd "$SCRIPT_DIR/.."
 
@@ -14,16 +13,11 @@ then
     export ERL_TOP=`pwd`
     export PATH=$ERL_TOP/bin:$PATH
     
-    echo "Changed ERL_TOP and PATH"
-
-
-    git checkout OTP-24.2.1
-
-    LAST_COMMIT_SHA=$(git rev-parse HEAD)
-
-    if [ ${LAST_COMMIT_SHA} != 7bf7f01683acf9b8f09bd8c7331854a9abc17f7d ]
+    # Checking out OTP-24.2.1
+    git checkout 7bf7f01683acf9b8f09bd8c7331854a9abc17f7d
+    if [ $? != 0 ]
     then
-        echo "Unexpected commit SHA"
+        echo "Could not check out desired Erlang version"
         exit 1
     fi
 
@@ -41,13 +35,10 @@ cd "$SCRIPT_DIR/../otp"
 export ERL_TOP=`pwd`
 export PATH=$ERL_TOP/bin:$PATH
 
-echo Changed ERL_TOP and PATH
-
 cd "$SCRIPT_DIR/.."
 
-rm -rf c_src/jqc
-rm -rf c_src/ext_libs
-
+(rm -rf c_src/jqc || true)
+(rm -rf c_src/ext_libs || true)
 rebar3 clean
 
 (mkdir c_src/ext_libs || true)
@@ -55,8 +46,6 @@ rebar3 clean
 cp "$ERL_TOP/lib/erl_interface/obj/x86_64-pc-linux-gnu/libei.a" c_src/ext_libs/
 
 JQ_MEMSAN_DEBUG=1 rebar3 compile
-
-cd "$OLD_DIR"
 
 echo "======================================================================================="
 echo "Things are now set up to run tests with address sanitizer (if nothing has gone wrong)"

--- a/test/jq_tests.erl
+++ b/test/jq_tests.erl
@@ -1,6 +1,14 @@
 -module(jq_tests).
 -include_lib("eunit/include/eunit.hrl").
 
+
+empty_input_test_() ->
+    [ ?_assertMatch({error, {jq_err_parse, _}}, jq:parse(<<".">>, <<"">>))
+    , ?_assertMatch({error, {jq_err_parse, _}}, jq:parse(<<".">>, <<" ">>))
+    , ?_assertMatch({ok,[<<"{}">>]}, jq:parse(<<"">>, <<"{}">>))
+    , ?_assertMatch({ok,[<<"{}">>]}, jq:parse(<<" ">>, <<"{}">>))
+    ].
+
 parse_error_test_() ->
     [ ?_assertMatch({error, {jq_err_parse, _}}, jq:parse(<<".">>, <<"{\"b\": }">>))
     , ?_assertMatch({error, {jq_err_parse, _}}, jq:parse(<<".">>, <<"{\"b\"- 2}">>))

--- a/test/jq_tests.erl
+++ b/test/jq_tests.erl
@@ -22,3 +22,38 @@ object_identifier_index_test_() ->
 array_index_test_() ->
     [ ?_assertEqual({ok,[<<"1">>,<<"2">>,<<"3">>]}, jq:parse(<<".b|.[]">>, <<"{\"b\": [1,2,3]}">>))
     ].
+
+get_tests_cases() ->
+    [ erlang:element(2, Test) ||
+      Test <-
+      lists:flatten([ 
+                     parse_error_test_(),
+                     process_error_test_(),
+                     object_identifier_index_test_(),
+                     array_index_test_()])].
+
+repeat_tests(Parent, ShouldStop, [], AllTestFuns) ->
+    case counters:get(ShouldStop, 1) of
+        0 ->
+            repeat_tests(Parent, ShouldStop, AllTestFuns, AllTestFuns);
+        _ -> 
+            Parent ! test_process_stopped
+    end;
+repeat_tests(Parent, ShouldStop, [TestFun | RemTestFuns], AllTestFuns) ->
+    TestFun(),
+    repeat_tests(Parent, ShouldStop, RemTestFuns, AllTestFuns).
+
+concurrent_queries_test() ->
+    NrOfTestProcess = 4,
+    TestTimeMs = 1000,
+    ShouldStop = counters:new(1, []),
+    TestCases = get_tests_cases(), 
+    Self = erlang:self(),
+    TestRunner = fun() ->
+                    repeat_tests(Self, ShouldStop, TestCases, TestCases)
+                 end,
+    [erlang:spawn_link(TestRunner) || _ <- lists:seq(1, NrOfTestProcess)], 
+    timer:sleep(TestTimeMs),
+    counters:add(ShouldStop, 1, 1),
+    [receive test_process_stopped -> ok end || _ <- lists:seq(1, NrOfTestProcess)], 
+    ok.


### PR DESCRIPTION
These commits fixes issues with the NIF C code and adds scripts that makes it easy to test the library with address sanitizer (detects memory leaks and other memory issues such as write after free).