### PR TITLE
perf: add thread local LRU caches for compiled programs

### DIFF
--- a/.github/workflows/eunit.yaml
+++ b/.github/workflows/eunit.yaml
@@ -34,6 +34,7 @@ jobs:
           brew update
           brew install erlang@${{ matrix.otp }}
           brew install automake
+          brew install bison
       - name: install rebar3
         run: |
           wget https://s3.amazonaws.com/rebar3/rebar3 && chmod +x rebar3

--- a/.github/workflows/eunit.yaml
+++ b/.github/workflows/eunit.yaml
@@ -6,6 +6,42 @@ on:
   - workflow_dispatch
 
 jobs:
+  mac:
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - macos-10.15
+          - macos-11
+        otp:
+          - 23
+          - 24
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          submodules: recursive
+      - name: Configure Homebrew cache
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/Library/Caches/Homebrew/
+            ~/Library/Caches/Homebrew/downloads/
+          key: brew-${{ matrix.os }}-${{ matrix.otp  }}
+      - name: prepare
+        run: |
+          brew update
+          brew install erlang@${{ matrix.otp }}
+          brew install automake
+      - name: install rebar3
+        run: |
+          wget https://s3.amazonaws.com/rebar3/rebar3 && chmod +x rebar3
+          cp ./rebar3 /usr/local/bin/rebar3
+      - name: release build
+        run: |
+          export PATH="/usr/local/opt/erlang@${{ matrix.otp }}/bin:$PATH"
+          ${GITHUB_WORKSPACE}/rebar3 eunit
   build:
     runs-on: ubuntu-20.04
 

--- a/.github/workflows/eunit.yaml
+++ b/.github/workflows/eunit.yaml
@@ -41,6 +41,7 @@ jobs:
           cp ./rebar3 /usr/local/bin/rebar3
       - name: release build
         run: |
+          export PATH="/usr/local/opt/bison/bin:$PATH"
           export PATH="/usr/local/opt/erlang@${{ matrix.otp }}/bin:$PATH"
           ${GITHUB_WORKSPACE}/rebar3 eunit
   build:

--- a/.github/workflows/eunit.yaml
+++ b/.github/workflows/eunit.yaml
@@ -6,44 +6,44 @@ on:
   - workflow_dispatch
 
 jobs:
-  mac:
-    strategy:
-      fail-fast: false
-      matrix:
-        os:
-          - macos-10.15
-          - macos-11
-        otp:
-          - 23
-          - 24
-    runs-on: ${{ matrix.os }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-        with:
-          submodules: recursive
-      - name: Configure Homebrew cache
-        uses: actions/cache@v2
-        with:
-          path: |
-            ~/Library/Caches/Homebrew/
-            ~/Library/Caches/Homebrew/downloads/
-          key: brew-${{ matrix.os }}-${{ matrix.otp  }}
-      - name: prepare
-        run: |
-          brew update
-          brew install erlang@${{ matrix.otp }}
-          brew install automake
-          brew install bison
-      - name: install rebar3
-        run: |
-          wget https://s3.amazonaws.com/rebar3/rebar3 && chmod +x rebar3
-          cp ./rebar3 /usr/local/bin/rebar3
-      - name: release build
-        run: |
-          export PATH="/usr/local/opt/bison/bin:$PATH"
-          export PATH="/usr/local/opt/erlang@${{ matrix.otp }}/bin:$PATH"
-          ${GITHUB_WORKSPACE}/rebar3 eunit
+  # mac:
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       os:
+  #         - macos-10.15
+  #         - macos-11
+  #       otp:
+  #         - 23
+  #         - 24
+  #   runs-on: ${{ matrix.os }}
+  #   steps:
+  #     - name: Checkout
+  #       uses: actions/checkout@v2
+  #       with:
+  #         submodules: recursive
+  #     - name: Configure Homebrew cache
+  #       uses: actions/cache@v2
+  #       with:
+  #         path: |
+  #           ~/Library/Caches/Homebrew/
+  #           ~/Library/Caches/Homebrew/downloads/
+  #         key: brew-${{ matrix.os }}-${{ matrix.otp  }}
+  #     - name: prepare
+  #       run: |
+  #         brew update
+  #         brew install erlang@${{ matrix.otp }}
+  #         brew install automake
+  #         brew install bison
+  #     - name: install rebar3
+  #       run: |
+  #         wget https://s3.amazonaws.com/rebar3/rebar3 && chmod +x rebar3
+  #         cp ./rebar3 /usr/local/bin/rebar3
+  #     - name: release build
+  #       run: |
+  #         export PATH="/usr/local/opt/bison/bin:$PATH"
+  #         export PATH="/usr/local/opt/erlang@${{ matrix.otp }}/bin:$PATH"
+  #         ${GITHUB_WORKSPACE}/rebar3 eunit
   build:
     runs-on: ubuntu-20.04
 

--- a/c_src/Makefile
+++ b/c_src/Makefile
@@ -6,8 +6,11 @@ BASEDIR := $(abspath $(CURDIR)/..)
 PROJECT ?= $(notdir $(BASEDIR))
 PROJECT := $(strip $(PROJECT))
 JQURL := https://github.com/terry-xiaoyu/jqc.git
-JQSRC_DIR := $(CURDIR)/jqc
+JQSRC_DIR := $(CURDIR)/libs/jqc
 JQSRC := $(JQSRC_DIR)/src/jv.c
+RDSURL := https://github.com/kjellwinblad/c_reusable_data_structures.git
+RDSSRC_DIR := $(CURDIR)/libs/c_reusable_data_structures
+RDSSRC := $(RDSSRC_DIR)/Makefile
 LIBJQ_DIR ?= $(JQSRC_DIR)/.libs
 LIBJQ_PREFIX := /usr/local
 EXT_LIBS := $(CURDIR)/ext_libs
@@ -34,6 +37,7 @@ LIBJQ_NAME := $(LIBJQ_DIR)/$(LIBJQ)
 ERTS_INCLUDE_DIR ?= $(shell erl -noshell -s init stop -eval "io:format(\"~ts/erts-~ts/include/\", [code:root_dir(), erlang:system_info(version)]).")
 ERL_INTERFACE_INCLUDE_DIR ?= $(shell erl -noshell -s init stop -eval "io:format(\"~ts\", [code:lib_dir(erl_interface, include)]).")
 JQ_INCLUDE_DIR ?= $(JQSRC_DIR)/src
+DS_INCLUDE_DIR ?= libs/c_reusable_data_structures
 
 ERL_INTERFACE_LIB_DIR ?= $(shell erl -noshell -s init stop -eval "io:format(\"~ts\", [code:lib_dir(erl_interface, lib)]).")
 
@@ -45,22 +49,22 @@ C_SRC_OUTPUT ?= $(PRIV_DIR)/$(PROJECT).so
 
 ifeq ($(UNAME_SYS), Darwin)
 	CC ?= cc
-	CFLAGS ?= $(EXTRA_C_FLAGS) -std=c99 -arch x86_64 -finline-functions -Wall -Wmissing-prototypes
+	CFLAGS ?= $(EXTRA_C_FLAGS) -std=c11 -arch x86_64 -finline-functions -Wall -Wno-missing-prototypes -Wno-unused-function
 	CXXFLAGS ?= -O3 -arch x86_64 -finline-functions -Wall
 	LDFLAGS ?= -arch x86_64 -flat_namespace -undefined suppress
 else ifeq ($(UNAME_SYS), FreeBSD)
 	CC ?= cc
-	CFLAGS ?= $(EXTRA_C_FLAGS) -std=c99 -finline-functions -Wall -Wmissing-prototypes
+	CFLAGS ?= $(EXTRA_C_FLAGS) -std=c11 -finline-functions -Wall -Wno-missing-prototypes -Wno-unused-function
 	CXXFLAGS ?= $(EXTRA_C_FLAGS) -finline-functions -Wall
 	LDFLAGS += -Wl,-rpath,$$ORIGIN
 else ifeq ($(UNAME_SYS), Linux)
 	CC ?= cc
-	CFLAGS ?= $(EXTRA_C_FLAGS) -std=c99 -finline-functions -Wall -Wmissing-prototypes
+	CFLAGS ?= $(EXTRA_C_FLAGS) -std=c11 -finline-functions -Wall -Wno-missing-prototypes -Wno-unused-function
 	CXXFLAGS ?= $(EXTRA_C_FLAGS) -finline-functions -Wall
 	LDFLAGS += -Wl,-rpath,$$ORIGIN
 endif
 
-CFLAGS += -I $(ERTS_INCLUDE_DIR) -I $(ERL_INTERFACE_INCLUDE_DIR) -I $(JQ_INCLUDE_DIR)
+CFLAGS += -I $(ERTS_INCLUDE_DIR) -I $(ERL_INTERFACE_INCLUDE_DIR) -I $(JQ_INCLUDE_DIR) -I $(DS_INCLUDE_DIR)
 CXXFLAGS += -fPIC -I $(ERTS_INCLUDE_DIR) -I $(ERL_INTERFACE_INCLUDE_DIR) -I $(JQ_INCLUDE_DIR)
 LDLIBS += -L $(ERL_INTERFACE_LIB_DIR) -L $(EXT_LIBS) -lei -l:libjq.a -l:libonig.a
 LDFLAGS += $(MEMSAN_FLAGS) -shared
@@ -110,8 +114,19 @@ build_erl_jq: $(OBJECTS)
 
 $(JQSRC):
 	git clone -b jq-1.6-emqx --single-branch $(JQURL) $(JQSRC_DIR)
+	((cd $(JQSRC_DIR) && git checkout 51df83ccf4808867eee79a011c71a93a121be1b6) || \
+	     (echo "Failed to check out jq commit" && \
+	      rm -r $(JQSRC_DIR) && \
+	      false))
 
-$(LIBJQ_NAME): $(JQSRC)
+$(RDSSRC):
+	git clone -b master --single-branch $(RDSURL) $(RDSSRC_DIR)
+	((cd $(RDSSRC_DIR) && git checkout 40cdd2544cfbd697ec9fa6d70fd971560cd9b4ff) || \
+	     (echo "Failed to check out c_reusable_data_structures commit" && \
+	      rm -r $(RDSSRC_DIR) && \
+	      false))
+
+$(LIBJQ_NAME): $(JQSRC) $(RDSSRC)
 	#ls -lart .libs/ modules/oniguruma/src/.libs/
 	cd $(JQSRC_DIR) && \
 	git submodule update --init && \

--- a/c_src/Makefile
+++ b/c_src/Makefile
@@ -125,7 +125,7 @@ $(JQSRC):
 
 $(RDSSRC):
 	git clone -b master --single-branch $(RDSURL) $(RDSSRC_DIR)
-	((cd $(RDSSRC_DIR) && git checkout 40cdd2544cfbd697ec9fa6d70fd971560cd9b4ff) || \
+	((cd $(RDSSRC_DIR) && git checkout 17b1b606b2f7b5fa6556ded6bfbbaf36c165ee84) || \
 	     (echo "Failed to check out c_reusable_data_structures commit" && \
 	      rm -r $(RDSSRC_DIR) && \
 	      false))

--- a/c_src/Makefile
+++ b/c_src/Makefile
@@ -5,10 +5,10 @@ BASEDIR := $(abspath $(CURDIR)/..)
 
 PROJECT ?= $(notdir $(BASEDIR))
 PROJECT := $(strip $(PROJECT))
-JQURL := https://github.com/terry-xiaoyu/jqc.git
+JQURL := https://github.com/emqx/jqc.git
 JQSRC_DIR := $(CURDIR)/libs/jqc
 JQSRC := $(JQSRC_DIR)/src/jv.c
-RDSURL := https://github.com/kjellwinblad/c_reusable_data_structures.git
+RDSURL := https://github.com/emqx/c_reusable_data_structures.git
 RDSSRC_DIR := $(CURDIR)/libs/c_reusable_data_structures
 RDSSRC := $(RDSSRC_DIR)/Makefile
 LIBJQ_DIR ?= $(JQSRC_DIR)/.libs

--- a/c_src/Makefile
+++ b/c_src/Makefile
@@ -64,7 +64,11 @@ else ifeq ($(UNAME_SYS), Linux)
 	LDFLAGS += -Wl,-rpath,$$ORIGIN
 endif
 
-CFLAGS += -I $(ERTS_INCLUDE_DIR) -I $(ERL_INTERFACE_INCLUDE_DIR) -I $(JQ_INCLUDE_DIR) -I $(DS_INCLUDE_DIR)
+STDC_NO_THREAD := $(shell ./check_if_threads_header_exists.sh "$(CC)" "$(CFLAGS)" threads.h)
+
+NO_PTHREAD := $(shell ./check_if_threads_header_exists.sh "$(CC)" "$(CFLAGS)" pthread.h)
+
+CFLAGS += -D__STDC_NO_THREADS__=$(STDC_NO_THREAD) -DJQ_NO_PTHREAD=$(NO_PTHREAD) -I $(ERTS_INCLUDE_DIR) -I $(ERL_INTERFACE_INCLUDE_DIR) -I $(JQ_INCLUDE_DIR) -I $(DS_INCLUDE_DIR)
 CXXFLAGS += -fPIC -I $(ERTS_INCLUDE_DIR) -I $(ERL_INTERFACE_INCLUDE_DIR) -I $(JQ_INCLUDE_DIR)
 LDLIBS += -L $(ERL_INTERFACE_LIB_DIR) -L $(EXT_LIBS) -lei -l:libjq.a -l:libonig.a
 LDFLAGS += $(MEMSAN_FLAGS) -shared

--- a/c_src/check_if_threads_header_exists.sh
+++ b/c_src/check_if_threads_header_exists.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+TEST_FILE=test_if_threads_header_exists.c
+echo "#include <$3>" > $TEST_FILE
+echo 'int main(){return 0;}' >> $TEST_FILE
+$1 $2 $TEST_FILE 2>/dev/null
+(test $? = 0 && echo 0) || echo 1
+rm $TEST_FILE

--- a/c_src/enif_jq.c
+++ b/c_src/enif_jq.c
@@ -1,18 +1,228 @@
 #include "enif_jq.h"
 #include "jv.h"
+#include "lru.h"
 
+
+#include <stdbool.h>
+#include <threads.h>
+
+// Thread local variable used by jqstate_cache_entry_shall_evict and
+// set when creating a new thread local jq_state cache to a
+// value (TODO: make this value configurable)
+static _Thread_local long jq_state_cache_max_size = 42;
+
+typedef struct JQStateCacheEntry_lru* JQStateCacheEntry_lru_ptr;
+static bool JQStateCacheEntry_lru_ptr_eq(
+        JQStateCacheEntry_lru_ptr* o1,
+        JQStateCacheEntry_lru_ptr* o2) {
+
+    (void)o1;
+    (void)o2;
+    // not used
+    assert(0);
+    return 0; 
+}
+// Generates structs and functions for a dynamic array (used to hold
+// pointers to all jq_state caches so they can be freed)
+DECLARE_DYNARR_DS(JQStateCacheEntry_lru_ptr,
+                  static,
+                  enif_alloc,
+                  enif_free,
+                  JQStateCacheEntry_lru_ptr_eq,
+                  1)
+
+// jq_state cache entry (hash and string is the key and state is the value)
+typedef struct {
+    size_t hash;
+    char* string;
+    jq_state* state;
+} JQStateCacheEntry;
+
+// Hash function for strings from https://stackoverflow.com/a/7666577
+// with small modifications
+static size_t hash_str(char *str) {
+    size_t hash = 5381;
+    int c;
+
+    while ((c = *str++))
+        hash = ((hash << 5) + hash) + c; /* hash * 33 + c */
+
+    return hash;
+}
+
+// Initialize a cache entry without any value
+static void jqstate_cache_entry_init(JQStateCacheEntry* entry, char* string) {
+    entry->hash = hash_str(string);    
+    entry->string = string;
+}
+
+static bool jqstate_cache_entry_eq(JQStateCacheEntry* o1, JQStateCacheEntry* o2) {
+    return o1->hash == o2->hash && (strcmp(o1->string, o2->string) == 0); 
+}
+
+static size_t jqstate_cache_entry_hash(JQStateCacheEntry* o) {
+   return o->hash;
+}
+
+static void jqstate_cache_entry_destroy(JQStateCacheEntry* o) {
+   jq_teardown(&o->state); 
+   enif_free(o->string);
+}
+
+// This function is used to decide if the least recently used
+// item should be evicted when inserting a new item into the
+// cache
+static bool jqstate_cache_entry_shall_evict(
+        size_t current_cache_size,
+        JQStateCacheEntry* value) {
+    (void)value;
+    return current_cache_size > jq_state_cache_max_size;
+}
+
+// Generates structs and functions for an LRU (Least Recently Used) cache.
+// The LRU cache is used to cache jq_state records to reduce the risk
+// that the same JQ filer program needs to be recompiled frequently.
+// Compilation of filter programs is very slow so this greatly improves
+// performance. Notice that jq_state is mutable and changes while a
+// filter program is executed so it is important that the caches are
+// thread local.
+DECLARE_LRUCACHE_DS(
+        JQStateCacheEntry,
+        static,
+        enif_alloc,
+        enif_free,
+        jqstate_cache_entry_eq,
+        jqstate_cache_entry_hash,
+        jqstate_cache_entry_destroy,
+        jqstate_cache_entry_shall_evict)
+
+// Data that is private to this version of the module
+typedef struct {
+    // The following two fields always have to be placed first
+    // in any new version of this library so that they can
+    // be found when doing hot upgrading.
+    
+    // The following field should be increased when a new version
+    // of this library is released (that can be hot upgraded to
+    // from a previous release).
+    int version;
+    // The following field should be increased by one when the
+    // library is hot upgraded (this is used to set the lock name
+    // to an unique name)
+    int nr_of_loads_before;
+
+    // The maximum size for the thread local jq_state caches
+    size_t lru_cache_max_size;
+    // thread local storage key used to find the jq_state cache
+    tss_t thread_local_jq_state_lru_cache_key;
+    // Dynamic array containing pointers to caches so that they can
+    // be freed when the module is unloaded
+    JQStateCacheEntry_lru_ptr_dynarr caches;
+    // Lock protecting the above filed from concurrent modifications
+    ErlNifMutex * lock;
+} module_private_data;
+
+// Returns the jq_state cache for the current thread (creates a new cache
+// if the current thread don't already have a cache). 
+static JQStateCacheEntry_lru * get_jqstate_cache(ErlNifEnv* env) {
+    module_private_data* data = enif_priv_data(env);
+    JQStateCacheEntry_lru * cache =
+        tss_get(data->thread_local_jq_state_lru_cache_key);
+    if (cache == NULL) {
+        // Create new cache
+        cache = JQStateCacheEntry_lru_new();
+        // Add new cache to array of caches so it can be freed on unload module
+        enif_mutex_lock(data->lock);
+        JQStateCacheEntry_lru_ptr_dynarr_push(&data->caches, cache);
+        enif_mutex_unlock(data->lock);
+        // Store the cache in the thread local storage for this thread
+        tss_set(data->thread_local_jq_state_lru_cache_key, cache);
+        // Set the max size so it can be seen from jqstate_cache_entry_shall_evict
+        jq_state_cache_max_size = data->lru_cache_max_size;
+    }
+    return cache;
+}
+
+// Function to generate an Erlang binary with an error message
+static ERL_NIF_TERM make_error_msg_bin(
+        ErlNifEnv* env,
+        const char* msg,
+        size_t msg_size) {
+
+    ERL_NIF_TERM err_msg_term;
+    memcpy(enif_make_new_binary(env, msg_size, &err_msg_term), msg, msg_size);
+    return err_msg_term;
+}
+
+// Returns a jq_state containing compiled version of
+// erl_jq_filter if compiling is successful and NULL
+// otherwise (the jq_state might get fetched from the
+// thread local cache if there is already a jq_state
+// for erl_jq_filter)
+jq_state* get_jq_state(
+        ErlNifEnv* env,
+        ERL_NIF_TERM* error_msg_bin_ptr,
+        int* ret,
+        ErlNifBinary erl_jq_filter) {
+
+    // Make sure the JQ filter is \0 terminated
+    ERL_NIF_TERM compile_input;
+    memcpy(enif_make_new_binary(
+                env,
+                erl_jq_filter.size + 1,
+                &compile_input),
+            erl_jq_filter.data,
+            erl_jq_filter.size);
+    enif_inspect_binary(env, compile_input, &erl_jq_filter);
+    erl_jq_filter.data[erl_jq_filter.size-1] = '\0';
+    // Check if there is already a jq filter in the LRU cache
+    JQStateCacheEntry_lru * cache = get_jqstate_cache(env);
+    JQStateCacheEntry new_entry;
+    jqstate_cache_entry_init(&new_entry, (char*)erl_jq_filter.data);
+    JQStateCacheEntry * cache_entry =
+        JQStateCacheEntry_lru_get(cache, new_entry);
+    if (cache_entry != NULL) {
+        // Return jq_state from cache
+        return cache_entry->state;
+    }
+    // No entry in the cache so we have to create a new jq_state
+    jq_state *jq = NULL;
+    jq = jq_init();
+    if (jq == NULL) {
+        *ret = JQ_ERROR_SYSTEM;
+        const char* error_message = "jq_init: Could not initialize jq";
+        *error_msg_bin_ptr =
+            make_error_msg_bin(env, error_message, strlen(error_message));
+        return NULL;
+    }
+    if (!jq_compile(jq, (char*)erl_jq_filter.data)) {
+        *ret = JQ_ERROR_COMPILE;
+        const char* error_message = "Compilation of jq filter failed";
+        *error_msg_bin_ptr =
+            make_error_msg_bin(env, error_message, strlen(error_message));
+        jq_teardown(&jq);
+        return NULL;
+    }
+    char * filter_program_string = enif_alloc(erl_jq_filter.size);
+    memcpy(filter_program_string, erl_jq_filter.data, erl_jq_filter.size);
+    new_entry.state = jq;
+    new_entry.string = filter_program_string;
+    JQStateCacheEntry_lru_add(cache, new_entry);
+    return jq;
+}
+
+// Used by the error callback function err_callback
 typedef struct {
     ErlNifEnv* env;
     ERL_NIF_TERM* error_msg_bin_ptr;
 } NifEnvAndErrBinPtr;
 
-// Forward declaration
-static ERL_NIF_TERM make_error_msg_bin(ErlNifEnv* env, const char* msg, size_t msg_size);
-
+// Callback given to jq before executing a jq_filter
 static void err_callback(void *data, jv err) {
     NifEnvAndErrBinPtr* env_and_msg_bin = data;
     ErlNifEnv* env = env_and_msg_bin->env; 
-    ERL_NIF_TERM* error_msg_bin_ptr = env_and_msg_bin->error_msg_bin_ptr; 
+    ERL_NIF_TERM* error_msg_bin_ptr =
+        env_and_msg_bin->error_msg_bin_ptr; 
     if (jv_get_kind(err) != JV_KIND_STRING)
         err = jv_dump_string(err, JV_PRINT_INVALID);
     *error_msg_bin_ptr =
@@ -22,22 +232,28 @@ static void err_callback(void *data, jv err) {
     jv_free(err);
 }
 
-static int process_json(jq_state *jq, jv value,
+// Process the JSON obejct value using the compiled filter program in the
+// given jq_state
+static int process_json(
+        jq_state *jq,
+        jv value,
         ErlNifEnv* env, ERL_NIF_TERM *ret_list, int flags, int dumpopts,
         ERL_NIF_TERM* error_msg_bin_ptr) {
+
   int ret = JQ_ERROR_UNKNOWN;
   jq_start(jq, value, flags);
   jv result;
   ERL_NIF_TERM list0 = enif_make_list(env, 0);
   while (jv_is_valid(result = jq_next(jq))) {
       ret = JQ_OK;
-      //jv_dump(result, dumpopts);
       jv res_jv_str = jv_dump_string(jv_copy(result), dumpopts);
       const char* res_str = jv_string_value(res_jv_str);
 
       ERL_NIF_TERM binterm;
       int binterm_sz = strlen(res_str);
-      memcpy(enif_make_new_binary(env, binterm_sz, &binterm), res_str, binterm_sz);
+      memcpy(enif_make_new_binary(env, binterm_sz, &binterm),
+             res_str,
+             binterm_sz);
       list0 = enif_make_list_cell(env, binterm, list0);
       jv_free(res_jv_str);
   }
@@ -47,16 +263,21 @@ static int process_json(jq_state *jq, jv value,
     // Uncaught jq exception
     jv msg = jv_invalid_get_msg(jv_copy(result));
     if (jv_get_kind(msg) == JV_KIND_STRING) {
-        size_t binsz = snprintf(NULL, 0, "jq error: %s\n", jv_string_value(msg));
-        char* bin_data = (char*)enif_make_new_binary(env, binsz, error_msg_bin_ptr);
+        size_t binsz =
+            snprintf(NULL, 0, "jq error: %s\n", jv_string_value(msg));
+        char* bin_data =
+            (char*)enif_make_new_binary(env, binsz, error_msg_bin_ptr);
         snprintf(bin_data, binsz, "jq error: %s\n", jv_string_value(msg));
     } else {
         msg = jv_dump_string(msg, 0);
         size_t binsz = snprintf(NULL, 0, "jq error (not a string): %s\n",
                 jv_string_value(msg));
-        char* bin_data = (char*)enif_make_new_binary(env, binsz, error_msg_bin_ptr);
-        snprintf(bin_data, binsz, "jq error (not a string): %s\n",
-                jv_string_value(msg));
+        char* bin_data =
+            (char*)enif_make_new_binary(env, binsz, error_msg_bin_ptr);
+        snprintf(bin_data,
+                 binsz,
+                 "jq error (not a string): %s\n",
+                 jv_string_value(msg));
     }
     ret = JQ_ERROR_PROCESS;
     jv_free(msg);
@@ -65,43 +286,32 @@ static int process_json(jq_state *jq, jv value,
   return ret;
 }
 
-static ERL_NIF_TERM make_error_msg_bin(ErlNifEnv* env, const char* msg, size_t msg_size) {
-    ERL_NIF_TERM err_msg_term;
-    memcpy(enif_make_new_binary(env, msg_size, &err_msg_term), msg, msg_size);
-    return err_msg_term;
-}
+// Helper function to create an error result term
+static ERL_NIF_TERM make_error_return(
+        ErlNifEnv* env,
+        int err_no,
+        ERL_NIF_TERM err_msg_bin) {
 
-static ERL_NIF_TERM make_error_return(ErlNifEnv* env, int err_no, ERL_NIF_TERM err_msg_bin) {
     const char* err_tag = err_tags[err_no];
     return enif_make_tuple2(env, enif_make_atom(env, "error"),
              enif_make_tuple2(env, enif_make_atom(env, err_tag), err_msg_bin));
 }
 
+// Helper function to create a term containing a success result term
 static ERL_NIF_TERM make_ok_return(ErlNifEnv* env, ERL_NIF_TERM result) {
     return enif_make_tuple2(env, enif_make_atom(env, "ok"), result);
 }
 
-static ERL_NIF_TERM parse_nif(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
-{
+// NIF function taking a binaries for a filter program and a JSON text
+// and returning the result of processing the JSON text with the
+// filter program 
+static ERL_NIF_TERM parse_nif(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[]) {
     ERL_NIF_TERM error_msg_bin; 
     // ----------------------------- init --------------------------------------
     jq_state *jq = NULL;
     int ret = JQ_ERROR_UNKNOWN;
     ERL_NIF_TERM ret_term;
     int dumpopts = 512; // JV_PRINT_SPACE1
-    jq = jq_init();
-    if (jq == NULL) {
-        ret = JQ_ERROR_SYSTEM;
-        const char* error_message = "jq_init: Could not initialize jq";
-        error_msg_bin =
-            make_error_msg_bin(env, error_message, strlen(error_message));
-        goto out;
-    }
-    NifEnvAndErrBinPtr env_and_msg_bin = {
-        .env = env,
-        .error_msg_bin_ptr = &error_msg_bin
-    };
-    jq_set_error_cb(jq, err_callback, &env_and_msg_bin);
 
     // --------------------------- read args -----------------------------------
     ErlNifBinary erl_jq_filter;
@@ -109,11 +319,23 @@ static ERL_NIF_TERM parse_nif(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[
     if (!enif_inspect_binary(env, argv[0], &erl_jq_filter) ||
         !enif_inspect_binary(env, argv[1], &erl_json_text)) {
         ret = JQ_ERROR_BADARG;
-        const char* error_message = "Expected arguments of type binary but got something else";
+        const char* error_message =
+            "Expected arguments of type binary but got something else";
         error_msg_bin =
             make_error_msg_bin(env, error_message, strlen(error_message));
         goto out;
     }
+    // --------- get jq state and compile filter program if not cached ---------
+    jq = get_jq_state(env, &error_msg_bin, &ret, erl_jq_filter);
+    if (jq == NULL) {
+        goto out;
+    }
+    // Set error callback here so that it gets the right env
+    NifEnvAndErrBinPtr env_and_msg_bin = {
+        .env = env,
+        .error_msg_bin_ptr = &error_msg_bin
+    };
+    jq_set_error_cb(jq, err_callback, &env_and_msg_bin);
 
     // ------------------------- parse input json -----------------------------
     // It is reasonable to assume that jv_parse_sized would not require the 
@@ -123,10 +345,13 @@ static ERL_NIF_TERM parse_nif(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[
     // is NULL terminated. A binary is used because small binaries are cheap
     // as they can be allocated on the process heap.
     ERL_NIF_TERM json_input;
-    memcpy(enif_make_new_binary(env, erl_json_text.size + 1, &json_input), erl_json_text.data, erl_json_text.size);
+    memcpy(enif_make_new_binary(env, erl_json_text.size + 1, &json_input),
+           erl_json_text.data,
+           erl_json_text.size);
     enif_inspect_binary(env, json_input, &erl_json_text);
     erl_json_text.data[erl_json_text.size-1] = '\0';
-    jv jv_json_text = jv_parse_sized((const char*)erl_json_text.data, erl_json_text.size - 1);
+    jv jv_json_text =
+        jv_parse_sized((const char*)erl_json_text.data, erl_json_text.size - 1);
     if (!jv_is_valid(jv_json_text)) {
         ret = JQ_ERROR_PARSE;
         // jv_invalid_get_msg destroys input jv object and returns new jv object
@@ -137,28 +362,18 @@ static ERL_NIF_TERM parse_nif(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[
                                jv_string_length_bytes(jv_copy(jv_json_text)));
         goto out;
     }
-    //jv_dump(jv_json_text, dumpopts);
-
-    // -------------------------- compile filter -------------------------------
-    // jq_compile requires that the input program (filter) is a NULL terminated string.
-    // Unfortunately, that forces us to create a new larger container that
-    // we can put the program inside. We use an Erlang binary for the container
-    // as small binaries can be efficiently allocated on the heap.
-    ERL_NIF_TERM compile_input;
-    memcpy(enif_make_new_binary(env, erl_jq_filter.size + 1, &compile_input), erl_jq_filter.data, erl_jq_filter.size);
-    enif_inspect_binary(env, compile_input, &erl_jq_filter);
-    erl_jq_filter.data[erl_jq_filter.size-1] = '\0';
-    if (!jq_compile(jq, (char*)erl_jq_filter.data)) {
-        ret = JQ_ERROR_COMPILE;
-        const char* error_message = "Compilation of jq filter failed";
-        error_msg_bin = make_error_msg_bin(env, error_message, strlen(error_message));
-        goto out;
-    }
 
     // ---------------------- process json text --------------------------------
     ERL_NIF_TERM ret_list = enif_make_list(env, 0);
     /*TODO: process_raw(jq, jv_json_text, &result, 0, dumpopts)*/
-    ret = process_json(jq, jv_copy(jv_json_text), env, &ret_list, 0, dumpopts, &error_msg_bin);
+    ret = process_json(
+            jq,
+            jv_copy(jv_json_text),
+            env,
+            &ret_list,
+            0,
+            dumpopts,
+            &error_msg_bin);
 
 out:// ----------------------------- release -----------------------------------
     switch (ret) {
@@ -178,7 +393,6 @@ out:// ----------------------------- release -----------------------------------
             break;
         }
     }
-    jq_teardown(&jq);
     // jq_next sometimes frees the input json and sometimes not so it is difficult
     // to keep track of how many copies (ref cnt inc) we have made.
     int ref_cnt = jv_get_refcnt(jv_json_text);
@@ -190,7 +404,8 @@ out:// ----------------------------- release -----------------------------------
 
 static ErlNifFunc nif_funcs[] = {
     /*
-       The parse_nif function seems to be very slow.
+       The parse_nif function seems to be very slow (at least when
+       given filter programs that are not in the cache).
        The Erlang VM acts very strangely when it is not scheduled
        on a dirty scheduler (for example, timer:sleep() suspends
        for a much longer time than is should).
@@ -198,9 +413,97 @@ static ErlNifFunc nif_funcs[] = {
     {"parse", 2, parse_nif, ERL_NIF_DIRTY_JOB_CPU_BOUND}
 };
 
-int upgrade(ErlNifEnv* env, void** priv_data, void** old_priv_data, ERL_NIF_TERM load_info)
-{
-	return 0;
+static int get_int_config(
+        ErlNifEnv* caller_env,
+        ERL_NIF_TERM load_info,
+        char* property_name,
+        int* res_wb) {
+
+    ERL_NIF_TERM property_atom = enif_make_atom(
+            caller_env,
+            property_name);
+    ERL_NIF_TERM property_term; 
+    if ( ! enif_get_map_value(
+            caller_env,
+            load_info,
+            property_atom,
+            &property_term)) {
+        // Incorrect load info
+        return 1;
+    }
+    if ( ! enif_get_int(
+               caller_env,
+               property_term,
+               res_wb)) {
+        // Incorrect load info
+        return 1;
+    }
+    return 0;
 }
 
-ERL_NIF_INIT(jq, nif_funcs, NULL, NULL, upgrade, NULL)
+static int load_helper(
+        ErlNifEnv* caller_env,
+        void** priv_data,
+        ERL_NIF_TERM load_info,
+        int nr_of_loads_before) {
+
+    int filter_program_lru_cache_max_size;
+    if ( get_int_config(
+                caller_env,
+                load_info,
+                "filter_program_lru_cache_max_size",
+                &filter_program_lru_cache_max_size) ) {
+        return 1;
+    }
+    module_private_data* data = enif_alloc(sizeof(module_private_data));
+    data->nr_of_loads_before = data->nr_of_loads_before + 1;
+    data->version = 0;
+    data->lru_cache_max_size = filter_program_lru_cache_max_size;
+    if (thrd_success !=
+        tss_create(&data->thread_local_jq_state_lru_cache_key, NULL)) {
+        enif_free(data);
+        return 1;
+    }
+    char buffer[128];
+    sprintf(buffer, "jq.module_private_data_v%d", nr_of_loads_before);
+    data->lock = enif_mutex_create(buffer);
+    if (data->lock == NULL) {
+        tss_delete(data->thread_local_jq_state_lru_cache_key);
+        enif_free(data);
+        return 1;
+    }
+    JQStateCacheEntry_lru_ptr_dynarr_init(&data->caches);
+    *priv_data = data;
+    return 0;
+}
+
+static int load(ErlNifEnv* caller_env, void** priv_data, ERL_NIF_TERM load_info) {
+    return load_helper(caller_env, priv_data, load_info, 0);
+}
+
+void unload(ErlNifEnv* caller_env, void* priv_data) {
+    module_private_data* data = priv_data; 
+    size_t nr_of_caches = JQStateCacheEntry_lru_ptr_dynarr_size(&data->caches);
+    JQStateCacheEntry_lru_ptr* cache_array =
+        JQStateCacheEntry_lru_ptr_dynarr_current_raw_array(&data->caches);
+    for (int i = 0; i < nr_of_caches; i++) {
+        JQStateCacheEntry_lru_free(cache_array[i]);
+    }
+    JQStateCacheEntry_lru_ptr_dynarr_destroy(&data->caches);
+    tss_delete(data->thread_local_jq_state_lru_cache_key);
+    enif_mutex_destroy(data->lock);
+    enif_free(data);
+}
+
+static int upgrade(
+        ErlNifEnv* env,
+        void** priv_data,
+        void** old_priv_data,
+        ERL_NIF_TERM load_info) {
+
+    module_private_data* old_data = *old_priv_data;
+    return load_helper(env, priv_data, load_info, old_data->nr_of_loads_before);
+}
+
+ERL_NIF_INIT(jq, nif_funcs, load, NULL, upgrade, unload)
+

--- a/c_src/enif_jq.h
+++ b/c_src/enif_jq.h
@@ -11,7 +11,7 @@
 extern jv jv_parse(const char* string);
 extern int jq_compile(jq_state *jq, const char* str);
 
-int upgrade(ErlNifEnv* env, void** priv_data, void** old_priv_data, ERL_NIF_TERM load_info);
+//int upgrade(ErlNifEnv* env, void** priv_data, void** old_priv_data, ERL_NIF_TERM load_info);
 
 enum {
     JQ_OK              =  0,

--- a/src/jq.app.src
+++ b/src/jq.app.src
@@ -1,5 +1,5 @@
 {application, jq,
- [{description, "An OTP library"},
+ [{description, "A library for executing JQ (https://stedolan.github.io/jq/) filter programs"},
   {vsn, "0.1.0"},
   {registered, []},
   {applications,

--- a/src/jq.erl
+++ b/src/jq.erl
@@ -31,7 +31,7 @@ init() ->
     end,
     %% Start the jq application here since it needs to be started so
     %% we can read its properties
-    application:start(jq),
+    application:load(jq),
     CacheMaxSize =
         application:get_env(jq, jq_filter_program_lru_cache_max_size, 500),
     JQNifConfig =

--- a/src/jq.erl
+++ b/src/jq.erl
@@ -5,7 +5,6 @@
 
 -define(APPNAME, jq).
 -define(LIBNAME, jq).
-
 parse(_, _) ->
     not_loaded(?LINE).
 
@@ -21,8 +20,13 @@ init() ->
         Dir ->
             filename:join(Dir, ?LIBNAME)
     end,
+    %% Start the jq application here since it needs to be started so
+    %% we can read its properties
+    application:start(jq),
+    CacheMaxSize =
+        application:get_env(jq, jq_filter_program_lru_cache_max_size, 500),
     JQNifConfig =
-        #{filter_program_lru_cache_max_size => 500},
+        #{filter_program_lru_cache_max_size => CacheMaxSize},
     erlang:load_nif(SoName, JQNifConfig).
 
 not_loaded(Line) ->

--- a/src/jq.erl
+++ b/src/jq.erl
@@ -21,7 +21,9 @@ init() ->
         Dir ->
             filename:join(Dir, ?LIBNAME)
     end,
-    erlang:load_nif(SoName, 0).
+    JQNifConfig =
+        #{filter_program_lru_cache_max_size => 500},
+    erlang:load_nif(SoName, JQNifConfig).
 
 not_loaded(Line) ->
     erlang:nif_error({not_loaded, [{module, ?MODULE}, {line, Line}]}).

--- a/src/jq.erl
+++ b/src/jq.erl
@@ -1,11 +1,20 @@
 -module(jq).
 
--export([parse/2]).
+-export([  parse/2
+         , set_filter_program_lru_cache_max_size/1
+         , get_filter_program_lru_cache_max_size/0]).
 -on_load(init/0).
 
 -define(APPNAME, jq).
 -define(LIBNAME, jq).
+
 parse(_, _) ->
+    not_loaded(?LINE).
+
+set_filter_program_lru_cache_max_size(_) ->
+    not_loaded(?LINE).
+
+get_filter_program_lru_cache_max_size() ->
     not_loaded(?LINE).
 
 init() ->

--- a/test/jq_tests.erl
+++ b/test/jq_tests.erl
@@ -1,44 +1,55 @@
 -module(jq_tests).
+
 -include_lib("eunit/include/eunit.hrl").
 
+wrap_setup_cleanup(TestCases) ->
+    {setup,
+     fun setup/0,
+     fun cleanup/1,
+     TestCases}.
 
-empty_input_test_() ->
+empty_input_t_() ->
     [ ?_assertMatch({error, {jq_err_parse, _}}, jq:parse(<<".">>, <<"">>))
     , ?_assertMatch({error, {jq_err_parse, _}}, jq:parse(<<".">>, <<" ">>))
     , ?_assertMatch({ok,[<<"{}">>]}, jq:parse(<<"">>, <<"{}">>))
     , ?_assertMatch({ok,[<<"{}">>]}, jq:parse(<<" ">>, <<"{}">>))
     ].
+empty_input_test_() -> wrap_setup_cleanup(empty_input_t_()).
 
-parse_error_test_() ->
+parse_error_t_() ->
     [ ?_assertMatch({error, {jq_err_parse, _}}, jq:parse(<<".">>, <<"{\"b\": }">>))
     , ?_assertMatch({error, {jq_err_parse, _}}, jq:parse(<<".">>, <<"{\"b\"- 2}">>))
     , ?_assertMatch({error, {jq_err_parse, _}}, jq:parse(<<".">>, <<"{\"b\"- 2}">>))
     ].
+parse_error_test_() -> wrap_setup_cleanup(parse_error_t_()).
 
-process_error_test_() ->
+process_error_t_() ->
     [ ?_assertMatch({error, {jq_err_process, _}}, jq:parse(<<".[1]">>, <<"{}">>))
     , ?_assertMatch({error, {jq_err_process, _}}, jq:parse(<<".a">>, <<"[1,2]">>))
     ].
+process_error_test_() -> wrap_setup_cleanup(process_error_t_()).
 
-object_identifier_index_test_() ->
+object_identifier_index_t_() ->
     [ ?_assertEqual({ok,[<<"{\"b\":2}">>]}, jq:parse(<<".">>, <<"{\"b\": 2}">>))
     , ?_assertEqual({ok,[<<"{\"b\":2}">>]}, jq:parse(<<".">>, <<"{\"b\":\n 2}">>))
     , ?_assertEqual({ok,[<<"2">>]}, jq:parse(<<".b">>, <<"{\"b\": 2}">>))
     , ?_assertEqual({ok,[<<"2">>]}, jq:parse(<<".a.b">>, <<"{\"a\":{\"b\": 2}}">>))
     ].
+object_identifier_index_test_() -> wrap_setup_cleanup(object_identifier_index_t_()).
 
-array_index_test_() ->
+array_index_t_() ->
     [ ?_assertEqual({ok,[<<"1">>,<<"2">>,<<"3">>]}, jq:parse(<<".b|.[]">>, <<"{\"b\": [1,2,3]}">>))
     ].
+array_index_test_() -> wrap_setup_cleanup(array_index_t_()).
 
 get_tests_cases() ->
     [ erlang:element(2, Test) ||
       Test <-
       lists:flatten([ 
-                     parse_error_test_(),
-                     process_error_test_(),
-                     object_identifier_index_test_(),
-                     array_index_test_()])].
+                     parse_error_t_(),
+                     process_error_t_(),
+                     object_identifier_index_t_(),
+                     array_index_t_()])].
 
 repeat_tests(Parent, ShouldStop, [], AllTestFuns, Cnt) ->
     case counters:get(ShouldStop, 1) of
@@ -66,7 +77,7 @@ concurrent_queries_test(NrOfTestProcess) ->
     erlang:display({'# of processes', NrOfTestProcess, 'Test Cases / Second', lists:sum(Cnts)}),
     ok.
 
-concurrent_queries_test_() ->
+concurrent_queries_t_() ->
     {timeout, erlang:system_info(schedulers) * 2,
      fun() ->
              erlang:display_nl(),
@@ -74,3 +85,11 @@ concurrent_queries_test_() ->
               || NrOfTestProcess <- lists:seq(1, erlang:system_info(schedulers))],
              ok
      end}.
+concurrent_queries_test_() -> wrap_setup_cleanup(concurrent_queries_t_()).
+
+setup() ->
+    ok.
+
+cleanup(_) ->
+    true = code:delete(jq),
+    true = code:soft_purge(jq).

--- a/test/jq_tests.erl
+++ b/test/jq_tests.erl
@@ -95,7 +95,7 @@ concurrent_queries_test(NrOfTestProcesses, PrintThroughput, CacheSize, TestTimeM
     ok.
 
 concurrent_queries_t_() ->
-    {timeout, erlang:system_info(schedulers) * 3,
+    {timeout, erlang:system_info(schedulers) * 14,
      fun() ->
              erlang:display_nl(),
              [(ok = concurrent_queries_test(NrOfTestProcess, true, 500, 1000))

--- a/test/jq_tests.erl
+++ b/test/jq_tests.erl
@@ -98,7 +98,7 @@ concurrent_queries_t_() ->
     {timeout, erlang:system_info(schedulers) * 3,
      fun() ->
              erlang:display_nl(),
-             [(ok = concurrent_queries_test(NrOfTestProcess, true, 500, 100))
+             [(ok = concurrent_queries_test(NrOfTestProcess, true, 500, 1000))
               || NrOfTestProcess <- lists:seq(1, erlang:system_info(schedulers))],
              [(ok = concurrent_queries_test(NrOfTestProcess, true, 0, 100))
               || NrOfTestProcess <- lists:seq(1, erlang:system_info(schedulers))],

--- a/test/jq_tests.erl
+++ b/test/jq_tests.erl
@@ -8,6 +8,12 @@ wrap_setup_cleanup(TestCases) ->
      fun cleanup/1,
      TestCases}.
 
+change_get_cache_size_t() ->
+    [ ?_assertMatch(ok, jq:set_filter_program_lru_cache_max_size(42)),
+      ?_assertMatch(42, jq:get_filter_program_lru_cache_max_size())
+    ].
+change_get_cache_size_test_() -> wrap_setup_cleanup(change_get_cache_size_t()).
+
 empty_input_t_() ->
     [ ?_assertMatch({error, {jq_err_parse, _}}, jq:parse(<<".">>, <<"">>))
     , ?_assertMatch({error, {jq_err_parse, _}}, jq:parse(<<".">>, <<" ">>))
@@ -45,7 +51,7 @@ array_index_test_() -> wrap_setup_cleanup(array_index_t_()).
 get_tests_cases() ->
     [ erlang:element(2, Test) ||
       Test <-
-      lists:flatten([ 
+      lists:flatten([empty_input_t_(), 
                      parse_error_t_(),
                      process_error_t_(),
                      object_identifier_index_t_(),
@@ -62,26 +68,49 @@ repeat_tests(Parent, ShouldStop, [TestFun | RemTestFuns], AllTestFuns, Cnt) ->
     TestFun(),
     repeat_tests(Parent, ShouldStop, RemTestFuns, AllTestFuns, Cnt + 1).
 
-concurrent_queries_test(NrOfTestProcess) ->
-    TestTimeMs = 1000,
+concurrent_queries_test(NrOfTestProcesses, PrintThroughput, CacheSize, TestTimeMs) ->
     ShouldStop = counters:new(1, []),
     TestCases = get_tests_cases(), 
     Self = erlang:self(),
+    OldCacheSize = jq:get_filter_program_lru_cache_max_size(),
+    ok = jq:set_filter_program_lru_cache_max_size(CacheSize),
     TestRunner = fun() ->
                     repeat_tests(Self, ShouldStop, TestCases, TestCases, 0)
                  end,
-    [erlang:spawn_link(TestRunner) || _ <- lists:seq(1, NrOfTestProcess)], 
+    [erlang:spawn_link(TestRunner) || _ <- lists:seq(1, NrOfTestProcesses)], 
     timer:sleep(TestTimeMs),
     counters:add(ShouldStop, 1, 1),
-    Cnts = [receive {test_process_stopped, Cnt} -> Cnt end || _ <- lists:seq(1, NrOfTestProcess)], 
-    erlang:display({'# of processes', NrOfTestProcess, 'Test Cases / Second', lists:sum(Cnts)}),
+    Cnts = [receive {test_process_stopped, Cnt} -> Cnt end || _ <- lists:seq(1, NrOfTestProcesses)], 
+    case PrintThroughput of
+        true ->
+            Throughput = erlang:floor(lists:sum(Cnts) / (TestTimeMs / 1000)),
+            erlang:display({'# of processes',
+                            NrOfTestProcesses,
+                            'Test Cases / Second',
+                            Throughput,
+                            'cache size',
+                            CacheSize})
+    end,
+    ok = jq:set_filter_program_lru_cache_max_size(OldCacheSize),
     ok.
 
 concurrent_queries_t_() ->
-    {timeout, erlang:system_info(schedulers) * 2,
+    {timeout, erlang:system_info(schedulers) * 3,
      fun() ->
              erlang:display_nl(),
-             [(ok = concurrent_queries_test(NrOfTestProcess))
+             [(ok = concurrent_queries_test(NrOfTestProcess, true, 500, 100))
+              || NrOfTestProcess <- lists:seq(1, erlang:system_info(schedulers))],
+             [(ok = concurrent_queries_test(NrOfTestProcess, true, 0, 100))
+              || NrOfTestProcess <- lists:seq(1, erlang:system_info(schedulers))],
+             [(ok = concurrent_queries_test(NrOfTestProcess, true, 1, 100))
+              || NrOfTestProcess <- lists:seq(1, erlang:system_info(schedulers))],
+             [(ok = concurrent_queries_test(NrOfTestProcess, true, 3, 100))
+              || NrOfTestProcess <- lists:seq(1, erlang:system_info(schedulers))],
+             [(ok = concurrent_queries_test(NrOfTestProcess, true, 5, 100))
+              || NrOfTestProcess <- lists:seq(1, erlang:system_info(schedulers))],
+             [(ok = concurrent_queries_test(NrOfTestProcess, true, 10, 100))
+              || NrOfTestProcess <- lists:seq(1, erlang:system_info(schedulers))],
+             [(ok = concurrent_queries_test(NrOfTestProcess, true, 2, 100))
               || NrOfTestProcess <- lists:seq(1, erlang:system_info(schedulers))],
              ok
      end}.


### PR DESCRIPTION
This PR adds thread local LRU (Least Recently Used) caches for caching `jq_state`s (holding the compiled versions of JQ filter programs). This greatly improves performance when the same filter program is used frequently. This is true when compiling the filter program is much slower than processing the JSON text with a compiled program (which seems to be very common). It is important the LRU cache is thread local since the jq_state struct instances are changed while they are used to process a JSON text.

The following table shows the throughput (processed `jq:parse/2` calls per second) reported by the test case `concurrent_queries_test_` before and after this commit on an Intel i5-1145G7 (16GB ram, 4 cores with hyper-threading):


```
N. of processes    Without LRU*     With LRU**
1                  100              290150
2                  200              422110
3                  270              625580
4                  360              731850
5                  330              725010
6                  420              716090
7                  410              758030
8                  250              777240

* Without LRU = processed `jq:parse/2` calls per second before this commit

** With LRU = processed `jq:parse/2` calls per second after this commit
```
