### PR TITLE
fix: put the version number in the shared library name

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,3 +38,18 @@ An Erlang NIF for [jq](https://github.com/stedolan/jq).
   The "test/address_sanitizer_setup.sh" scripts compiles an
   erlang VM with address sanitizer support and don't need
   to be executed every time a change is made to the NIF.
+
+- About hot upgrading
+
+This library supports hot code reloading/upgrading. For the hot upgrade from an
+old version to a new version to go smoothly, the new version needs to have a
+different number in the version macro (`-define(VERSION, NUM)`) in
+`src/jq.erl`. This version number is read by the `Makefile` for the shared
+library. The `Makefile` produces a shared library with the version number in
+its file name. [Most operating systems require that the new shared library has
+a different name than the previous
+one](https://www.erlang.org/doc/man/erlang.html#load_nif-2) (otherwise, the
+operating system will not load the new library). One should thus always
+increase the version number in the version macro before releasing a new version
+of this library.
+

--- a/c_src/Makefile
+++ b/c_src/Makefile
@@ -2,6 +2,9 @@
 UNAME_SYS := $(shell uname -s)
 CURDIR := $(shell pwd)
 BASEDIR := $(abspath $(CURDIR)/..)
+VERSION := $(shell ./get_version.sh $(BASEDIR)) 
+VERSION := $(strip $(VERSION))
+JQERLMODSRC := $(BASEDIR)/src/jq.erl
 
 PROJECT ?= $(notdir $(BASEDIR))
 PROJECT := $(strip $(PROJECT))
@@ -43,7 +46,7 @@ ERL_INTERFACE_LIB_DIR ?= $(shell erl -noshell -s init stop -eval "io:format(\"~t
 
 PRIV_DIR = $(CURDIR)/../priv
 C_SRC_DIR = $(CURDIR)
-C_SRC_OUTPUT ?= $(PRIV_DIR)/$(PROJECT).so
+C_SRC_OUTPUT ?= $(PRIV_DIR)/$(PROJECT)$(VERSION).so
 
 # System type and C compiler/flags.
 
@@ -68,7 +71,7 @@ STDC_NO_THREAD := $(shell ./check_if_threads_header_exists.sh "$(CC)" "$(CFLAGS)
 
 NO_PTHREAD := $(shell ./check_if_threads_header_exists.sh "$(CC)" "$(CFLAGS)" pthread.h)
 
-CFLAGS += -D__STDC_NO_THREADS__=$(STDC_NO_THREAD) -DJQ_NO_PTHREAD=$(NO_PTHREAD) -I $(ERTS_INCLUDE_DIR) -I $(ERL_INTERFACE_INCLUDE_DIR) -I $(JQ_INCLUDE_DIR) -I $(DS_INCLUDE_DIR)
+CFLAGS += -DVERSION=$(VERSION) -D__STDC_NO_THREADS__=$(STDC_NO_THREAD) -DJQ_NO_PTHREAD=$(NO_PTHREAD) -I $(ERTS_INCLUDE_DIR) -I $(ERL_INTERFACE_INCLUDE_DIR) -I $(JQ_INCLUDE_DIR) -I $(DS_INCLUDE_DIR)
 CXXFLAGS += -fPIC -I $(ERTS_INCLUDE_DIR) -I $(ERL_INTERFACE_INCLUDE_DIR) -I $(JQ_INCLUDE_DIR)
 LDLIBS += -L $(ERL_INTERFACE_LIB_DIR) -L $(EXT_LIBS) -lei -l:libjq.a -l:libonig.a
 LDFLAGS += $(MEMSAN_FLAGS) -shared
@@ -104,17 +107,8 @@ build_erl_jq: $(OBJECTS)
 	@mkdir -p $(BASEDIR)/priv/
 	$(link_verbose) $(CC) $(OBJECTS) $(LDFLAGS) $(LDLIBS) -o $(C_SRC_OUTPUT)
 
-%.o: %.c $(LIBJQ_NAME)
+%.o: %.c $(LIBJQ_NAME) $(JQERLMODSRC) $(RDSSRC)
 	$(COMPILE_C) $(OUTPUT_OPTION) $<
-
-%.o: %.cc $(LIBJQ_NAME)
-	$(COMPILE_CPP) $(OUTPUT_OPTION) $<
-
-%.o: %.C $(LIBJQ_NAME)
-	$(COMPILE_CPP) $(OUTPUT_OPTION) $<
-
-%.o: %.cpp $(LIBJQ_NAME)
-	$(COMPILE_CPP) $(OUTPUT_OPTION) $<
 
 $(JQSRC):
 	git clone -b jq-1.6-emqx --single-branch $(JQURL) $(JQSRC_DIR)
@@ -130,7 +124,7 @@ $(RDSSRC):
 	      rm -r $(RDSSRC_DIR) && \
 	      false))
 
-$(LIBJQ_NAME): $(JQSRC) $(RDSSRC)
+$(LIBJQ_NAME): $(JQSRC)
 	#ls -lart .libs/ modules/oniguruma/src/.libs/
 	cd $(JQSRC_DIR) && \
 	git submodule update --init && \
@@ -142,8 +136,6 @@ $(LIBJQ_NAME): $(JQSRC) $(RDSSRC)
 	make -C modules/oniguruma/ && \
 	make src/builtin.inc && \
 	make libjq.la && \
-	cp .libs/$(LIBJQ) $(PRIV_DIR)/ && \
-	cp modules/oniguruma/src/.libs/$(LIBONIG) $(PRIV_DIR)/ && \
 	(mkdir $(EXT_LIBS) || true) && \
 	cp .libs/libjq.* $(EXT_LIBS)/ && \
 	cp modules/oniguruma/src/.libs/libonig.* $(EXT_LIBS)/ && \

--- a/c_src/enif_jq.c
+++ b/c_src/enif_jq.c
@@ -79,9 +79,8 @@ typedef struct {
     // in any new version of this library so that they can
     // be found when doing hot upgrading.
     
-    // The following field should be increased when a new version
-    // of this library is released (that can be hot upgraded to
-    // from a previous release).
+    // The following field is set to the version which is given
+    // when the library is loaded
     int version;
     // The following field should be increased by one when the
     // library is hot upgraded (this is used to set the lock name
@@ -559,13 +558,22 @@ static int load_helper(
     if (filter_program_lru_cache_max_size < 0) {
         return 1;
     }
+    int version;
+    if ( get_int_config(
+                caller_env,
+                load_info,
+                "version",
+                &version) ) {
+        return 1;
+    }
     module_private_data* data = enif_alloc(sizeof(module_private_data));
     if (data == NULL) {
         fprintf(stderr, "ERROR: enif_alloc returned NULL (out of memory?)\n");
         return 1;
     }
-    data->nr_of_loads_before = data->nr_of_loads_before + 1;
-    data->version = 0;
+    data->nr_of_loads_before = nr_of_loads_before + 1;
+    data->version = version;
+    assert(data->version == VERSION);
     data->lru_cache_max_size = filter_program_lru_cache_max_size;
     if (thrd_success !=
         tss_create(&data->thread_local_jq_state_lru_cache_key, NULL)) {

--- a/c_src/get_version.sh
+++ b/c_src/get_version.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+
+grep '.*define.*(.*VERSION' "$1"/src/jq.erl | sed -e 's/.*VERSION.*,.*\([[:digit:]]\+\).*/\1/'

--- a/src/jq.erl
+++ b/src/jq.erl
@@ -6,7 +6,8 @@
 -on_load(init/0).
 
 -define(APPNAME, jq).
--define(LIBNAME, jq).
+-define(VERSION, 1).
+-define(LIBNAME, "jq").
 
 parse(_, _) ->
     not_loaded(?LINE).
@@ -18,16 +19,17 @@ get_filter_program_lru_cache_max_size() ->
     not_loaded(?LINE).
 
 init() ->
+    LibNameAndVersion = ?LIBNAME ++ erlang:integer_to_list(?VERSION),
     SoName = case code:priv_dir(?APPNAME) of
         {error, bad_name} ->
             case filelib:is_dir(filename:join(["..", priv])) of
                 true ->
-                    filename:join(["..", priv, ?LIBNAME]);
+                    filename:join(["..", priv, LibNameAndVersion]);
                 _ ->
-                    filename:join([priv, ?LIBNAME])
+                    filename:join([priv, LibNameAndVersion])
             end;
         Dir ->
-            filename:join(Dir, ?LIBNAME)
+            filename:join(Dir, LibNameAndVersion)
     end,
     %% Start the jq application here since it needs to be started so
     %% we can read its properties
@@ -35,7 +37,8 @@ init() ->
     CacheMaxSize =
         application:get_env(jq, jq_filter_program_lru_cache_max_size, 500),
     JQNifConfig =
-        #{filter_program_lru_cache_max_size => CacheMaxSize},
+        #{filter_program_lru_cache_max_size => CacheMaxSize,
+          version => ?VERSION},
     erlang:load_nif(SoName, JQNifConfig).
 
 not_loaded(Line) ->


### PR DESCRIPTION
This commit creates a define with a version number. The compiled shared
library will have this number in its name. This is important because
most operating systems refuse to load a shared library that has the same
name as a shared library that is already loaded.

The commit also includes a fix for the number of loads counter that is
included in the modules private data.