### PR TITLE
fix: prevent crash when using include and fix compile error handling

### DIFF
--- a/c_src/erlang_jq_nif.c
+++ b/c_src/erlang_jq_nif.c
@@ -191,26 +191,6 @@ jq_state* get_jq_state(
     return jq;
 }
 
-// Used by the error callback function err_callback
-typedef struct {
-    ErlNifEnv* env;
-    ERL_NIF_TERM* error_msg_bin_ptr;
-} NifEnvAndErrBinPtr;
-
-// Callback given to jq before executing a jq_filter
-static void err_callback(void *data, jv err) {
-    NifEnvAndErrBinPtr* env_and_msg_bin = data;
-    ErlNifEnv* env = env_and_msg_bin->env; 
-    ERL_NIF_TERM* error_msg_bin_ptr =
-        env_and_msg_bin->error_msg_bin_ptr; 
-    if (jv_get_kind(err) != JV_KIND_STRING)
-        err = jv_dump_string(err, JV_PRINT_INVALID);
-    *error_msg_bin_ptr =
-        make_error_msg_bin(env,
-                           jv_string_value(err),
-                           jv_string_length_bytes(jv_copy(err)));
-    jv_free(err);
-}
 
 // Process the JSON obejct value using the compiled filter program in the
 // given jq_state

--- a/c_src/erlang_jq_port.c
+++ b/c_src/erlang_jq_port.c
@@ -167,6 +167,7 @@ static ssize_t read_exact(byte *buf, size_t len) {
         for (size_t i = 0; i < len; i++) {
             fputc(buf[i], record_input_file); 
         }
+        fflush(record_input_file);
     }
     return got;
 }

--- a/test/jq_tests.erl
+++ b/test/jq_tests.erl
@@ -43,6 +43,12 @@ empty_input_t_() ->
      , ?_assertMatch({ok,[<<"{}">>]}, jq:process_json(<<" ">>, <<"{}">>))].
 empty_input_test_() -> wrap_setup_cleanup(empty_input_t_()).
 
+include_t_() ->
+    [
+       ?_assertMatch({error, {jq_err_compile, _}}, jq:process_json(<<"include \"i_do_not_exist\";.">>, <<"1">>))
+    ].
+include_test_() -> wrap_setup_cleanup(include_t_()).
+
 parse_error_t_() ->
     [ ?_assertMatch({error, {jq_err_parse, _}}, jq:process_json(<<".">>, <<"{\"b\": }">>))
     , ?_assertMatch({error, {jq_err_parse, _}}, jq:process_json(<<".">>, <<"{\"b\"- 2}">>))
@@ -136,7 +142,8 @@ advanced_filter_programs_test_() ->
 get_tests_cases() ->
     [ erlang:element(2, Test) ||
       Test <-
-      lists:flatten([empty_input_t_(), 
+      lists:flatten([empty_input_t_(),
+                     include_t_(),
                      parse_error_t_(),
                      process_error_t_(),
                      object_identifier_index_t_(),


### PR DESCRIPTION
This commit fixes https://github.com/emqx/jq/issues/20

It also fixes error handling so that error messages reported by calls
to jq_report_error from within the jq library are included in the
error return value and are not printed.