### PR TITLE
feat: add support for timeout when processing JSON with jq

### DIFF
--- a/src/jq.erl
+++ b/src/jq.erl
@@ -9,6 +9,7 @@
 
 -export([
            process_json/2
+         , process_json/3
          , set_filter_program_lru_cache_max_size/1
          , get_filter_program_lru_cache_max_size/0
          , implementation_module/0
@@ -25,8 +26,54 @@
 %%
 %% @param JSONText Binary or iodata containing a valid JSON object
 %%
+%% @param TimeoutMs specifies a timeout in milliseconds (or the atom infinity
+%% to never timeout). The function will cancel the execution of the jq program
+%% and return an error tuple if the execution has not finished within the
+%% timeout.
+%%
 %% @returns ok tuple with list of binaries with resulting JSON objects or error
-%% tuple in case of an error
+%% tuple in case of an error (a timeout also counts as an error)
+
+
+-spec process_json(FilterProgram, JSONText, TimeoutMs) -> Result when
+    FilterProgram :: iodata(),
+    JSONText :: iodata(),
+    TimeoutMs :: non_neg_integer() | infinity,
+    Result :: {ok, [binary()]} | {error, Reason},
+    Reason :: term().
+
+
+process_json(FilterProgram, JSONText, TimeoutMs)
+  when is_binary(FilterProgram), is_binary(JSONText), size(FilterProgram) > 0, size(JSONText) > 0 ->
+    case {binary_part(FilterProgram, size(FilterProgram) - 1, 1),
+          binary_part(JSONText, size(JSONText) - 1, 1)} of
+        {<<"\0">>, <<"\0">>} ->
+            Mod = implementation_module(),
+            case TimeoutMs of
+                infinity ->
+                    Mod:process_json(FilterProgram, JSONText);
+                TimeoutMs when (not is_integer(TimeoutMs)) orelse TimeoutMs < 0 ->
+                    {error,
+                     {bad_timeout_val,
+                      io_lib:format_prompt("Needs positive integer or infinity but got ~p", [TimeoutMs])}};
+                TimeoutMs ->
+                    %% Timeouts are only supported by the port implementation so
+                    %% for now we use the port implementation when a timeout is
+                    %% given, even if the user has configured the library to use
+                    %% the NIF implementation.
+                    jq_port:process_json(FilterProgram, JSONText, TimeoutMs)
+            end;
+        _ ->
+            %% Force execution of the next clause so the inputs gets 0 terminated
+            process_json([FilterProgram], [JSONText], TimeoutMs)
+    end;
+process_json(FilterProgram, JSONText, TimeoutMs) ->
+    process_json(erlang:iolist_to_binary([FilterProgram, <<"\0">>]),
+                 erlang:iolist_to_binary([JSONText, <<"\0">>]),
+                 TimeoutMs). 
+
+%% @doc Calling this function is identical to calling
+%% process_json(FilterProgram, JSONText, infinity)
 
 
 -spec process_json(FilterProgram, JSONText) -> Result when
@@ -35,20 +82,8 @@
     Result :: {ok, [binary()]} | {error, Reason},
     Reason :: term().
 
-process_json(FilterProgram, JSONText)
-  when is_binary(FilterProgram), is_binary(JSONText), size(FilterProgram) > 0, size(JSONText) > 0 ->
-    case {binary_part(FilterProgram, size(FilterProgram) - 1, 1),
-          binary_part(JSONText, size(JSONText) - 1, 1)} of
-        {<<"\0">>, <<"\0">>} ->
-            %% erlang:display(null_terminated),
-            Mod = implementation_module(),
-            Mod:process_json(FilterProgram, JSONText);
-        _ ->
-            process_json([FilterProgram], [JSONText])
-    end;
 process_json(FilterProgram, JSONText) ->
-    process_json(erlang:iolist_to_binary([FilterProgram, <<"\0">>]),
-                 erlang:iolist_to_binary([JSONText, <<"\0">>])). 
+    process_json(FilterProgram, JSONText, infinity). 
 
 %% @doc Get the implementation module that is currently used.
 

--- a/src/jq_port.erl
+++ b/src/jq_port.erl
@@ -26,7 +26,7 @@
 
 %% Public interface
 
--export([process_json/2]).
+-export([process_json/2, process_json/3]).
 
 %% Configuration functions
 -export([
@@ -108,12 +108,16 @@ set_filter_program_lru_cache_max_size(NewSize)
     end,
     do_op_ensure_started(Op).
 
-process_json(FilterProgram, JSONText)
+process_json(FilterProgram, JSONText) ->
+    process_json(FilterProgram, JSONText, infinity).
+
+
+process_json(FilterProgram, JSONText, TimeoutMs)
   when is_binary(FilterProgram), is_binary(JSONText) ->
     Op =
     fun() ->
             gen_server:call(port_server(),
-                            {jq_process_json, FilterProgram, JSONText},
+                            {jq_process_json, FilterProgram, JSONText, TimeoutMs},
                             infinity)
     end,
     do_op_ensure_started(Op).
@@ -202,22 +206,38 @@ kill_port(Port) ->
         {Port, {data, <<"exiting">>}} -> 
             ok
     after TimeToWaitForExitingConfirmation ->
+              {os_pid, OsPid} = erlang:port_info(Port, os_pid),
+              case OsPid of
+                  OsPid when is_integer(OsPid) ->
+                      KillCmdFormat =
+                      case os:type() of
+                          {win32, _} ->
+                              "taskkill /PID ~p /F";
+                          {_, _ } -> 
+                              %% We assume it is UNIX or some other OS
+                              %% with an UNIX kill command.
+                              "kill -9 ~p"
+                      end,
+                      %% This is theoretically unsafe as the process
+                      %% might have died and the its PID got reused.
+                      %% However, on mainstream systems it should not
+                      %% be a problem as it is unlikely that the same
+                      %% PID will get reused very quickly.
+                      os:cmd(io_lib:format(KillCmdFormat, [OsPid]));
+                  _ ->
+                      %% Process should be closed already if we did
+                      %% not get an integer
+                      ok
+              end,
               ok
     end,
-    %% Send close to the port just in case the port does not respond to the exit command for some reason
-    Port ! {self(), close},
     ok.
 
 send_msg_to_port(Port, Msg) ->
     erlang:port_command(Port, Msg).
 
 receive_msg_from_port(Port) ->
-    receive
-        {Port, {data, Data}} ->
-            Data;
-        {'EXIT', Port, Reason} ->
-            {error, port_exited_during_op, Port, Reason}
-    end.
+    receive_msg_from_port(Port, infinity).
 
 receive_msg_from_port(Port, TimeoutMs) ->
     receive
@@ -226,7 +246,7 @@ receive_msg_from_port(Port, TimeoutMs) ->
         {'EXIT', Port, Reason} ->
             {error, port_exited_during_op, Port, Reason}
     after TimeoutMs ->
-              {error, timeout_while_waiting_for_msg}
+            {error, timeout_while_waiting_for_msg}
     end.
 
 receive_ok_msg_from_port(Port, State) ->
@@ -237,16 +257,32 @@ receive_ok_msg_from_port(Port, State) ->
  
 
 misbehaving_port_program(State, ErrorClass, Reason) ->
-    logger:error(io_lib:format("jq port program responsed in unexepected way (state = ~p error_class ~p reason ~p , restarting)",
-                               [State, ErrorClass, Reason])),
+    Ret =
+        case Reason of
+            {timeout_while_waiting_for_msg, TimeoutMs} ->
+                ErrorMsgFormatTO = 
+                    "jq program canceled as it took too long time to execute (timeout set to ~w ms)",
+                ErrorMsgTO =
+                    erlang:iolist_to_binary(io_lib:format(ErrorMsgFormatTO, [TimeoutMs])),
+                logger:error(ErrorMsgTO),
+                {error, {timeout, ErrorMsgTO}};
+            _ ->
+                ErrorMsgFormat = 
+                    ("jq port program responded in unexpected way "
+                     "(state = ~p error_class ~p reason ~p , restarting)"),
+                ErrorMsg = erlang:iolist_to_binary(io_lib:format(ErrorMsgFormat,
+                                                                 [State, ErrorClass, Reason])),
+                logger:error(ErrorMsg),
+                {error, {misbehaving_port_program, ErrorClass, Reason}}
+        end,
     OldPort = state_port(State), 
     kill_port(OldPort),
     NewPort = start_port_program(),
     NewState = State#{port => NewPort},
-    {reply, {error, {misbehaving_port_program, ErrorClass, Reason}}, NewState}.
+    {reply, Ret, NewState}.
 
-receive_process_json_result(Port) ->
-    case receive_msg_from_port(Port) of
+receive_process_json_result(Port, TimeoutMs) ->
+    case receive_msg_from_port(Port, TimeoutMs) of
         <<"ok">> ->
             SizeStr = receive_msg_from_port(Port),
             NrOfItems = erlang:binary_to_integer(SizeStr),
@@ -254,9 +290,14 @@ receive_process_json_result(Port) ->
         <<"error">> ->
             [ErrorType, ErrorMsg] = receive_result_blobs(Port, 2, []),
             {error, {erlang:binary_to_atom(ErrorType), ErrorMsg}};
+        {error, timeout_while_waiting_for_msg} ->
+            error({timeout_while_waiting_for_msg, TimeoutMs});
         Unexpected ->
             error({unexpected_response_from_port, Unexpected})
     end.
+
+receive_process_json_result(Port) ->
+    receive_process_json_result(Port, infinity).
 
 new_state_after_process_json(State) ->
     RestartPeriod = state_restart_period(State),
@@ -271,13 +312,15 @@ new_state_after_process_json(State) ->
             State#{processed_json_calls => NrOfCalls + 1}
     end.
 
-handle_call({jq_process_json, FilterProgram, JSONText}, _From, State) ->
+handle_call({jq_process_json, FilterProgram, JSONText, TimeoutMs}, _From, State) ->
     Port = state_port(State),
     try
         send_msg_to_port(Port, <<"process_json\0">>), 
         send_msg_to_port(Port, FilterProgram), 
         send_msg_to_port(Port, JSONText), 
-        {reply, receive_process_json_result(Port), new_state_after_process_json(State)}
+        {reply,
+         receive_process_json_result(Port, TimeoutMs),
+         new_state_after_process_json(State)}
     catch
         ErrorClass:Reason ->
             misbehaving_port_program(State, ErrorClass, Reason)


### PR DESCRIPTION
This commit adds the function `jq:process_json/3` which is like `jq:process_json/2` except that the user can also set a timeout. If a timeout is set and the execution of the jq program has not finished within the timeout time, the execution of the jq program
will be terminated and an error will be returned. This is an important feature since jq programs might execute forever. This commit only implements timeout support in the port program implementation so the port program implementation is used whenever a timeout is set, even if the user has configured the library to use the NIF implementation (timeout support for the NIF implementation might be added in a later commit).