### PR TITLE
Add support for timeouts in the NIF backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ application is loaded (the jq Erlang application is loaded automatically when
 * `jq_filter_program_lru_cache_max_size` (default value = 500) - Sets the size of
   the LRU caches that are holding compiled JQ programs to prevent frequent
   expensive recompilation of the same program.
-* `jq_implementation_module` (default value = `jq_port`) - Sets the implementation
+* `jq_implementation_module` (default value = `jq_nif`) - Sets the implementation
   that will be used. The options are:
   * `jq_port` - This implementation uses a port program to interact with jq.
     This is the most safe option as a bug in jq cannot
@@ -58,11 +58,13 @@ application is loaded (the jq Erlang application is loaded automatically when
   * `jq_nif` - This implementation uses a NIF library to interact with jq. This
     option is faster than the `jq_port` option but it is also less safe even
     though we are currently not not aware of any problems with this option.
+  One can use the function `jq:set_implementation_module/2` to change the
+  implementation while the application is running.
 * `jq_port_nr_of_jq_port_servers` (default value =
   `erlang:system_info(schedulers)`) (only relevant for the `jq_port` option) -
   Use this option to set how many port programs that will handle jq requests.
   Higher values can lead to better performance (due to parallelism) at the
-  expense of increased memory usage and cache locality. 
+  expense of increased memory usage and worse cache locality. 
 * `jq_port_restart_period` (default value = 1000000) (only relevant for the
   `jq_port` option) - Use this option to set how many `jq:process_json/2` calls
   a port program can process before it is restarted. This is a safety option

--- a/c_src/Makefile
+++ b/c_src/Makefile
@@ -13,9 +13,11 @@ NIF_MODULE := jq_nif
 JQURL := https://github.com/emqx/jqc.git
 JQSRC_DIR := libs/jqc
 JQSRC := $(JQSRC_DIR)/src/jv.c
+JQSRC_VERSION := 73c51aa79b67b99c575ef8923aa0c03cd87a7ac1
 RDSURL := https://github.com/emqx/c_reusable_data_structures.git
 RDSSRC_DIR := libs/c_reusable_data_structures
 RDSSRC := $(RDSSRC_DIR)/Makefile
+RDSSRC_VERSION := 77c7a96416065a839417e5078fce9ba9a14982dc
 LIBJQ_DIR ?= $(JQSRC_DIR)/.libs
 LIBJQ_PREFIX := /usr/local
 EXT_LIBS := ext_libs
@@ -104,7 +106,9 @@ PORT_OBJECTS = $(addsuffix .o, $(basename $(PORT_SOURCES)))
 COMPILE_C = $(c_verbose) $(CC) $(CFLAGS) $(CPPFLAGS) -c
 COMPILE_CPP = $(cpp_verbose) $(CXX) $(CXXFLAGS) $(CPPFLAGS) -c
 
-.PHONY: clean
+.PHONY: clean check_jqc_version all check_rds_version
+
+all: check_jqc_version check_rds_version $(C_SRC_OUTPUT)
 
 ifeq ($(JQ_MEMSAN_DEBUG), 1)
 $(C_SRC_OUTPUT): $(OBJECTS) port_nif_common.h
@@ -131,16 +135,25 @@ $(ERL_PORT_PROGRAM): $(PORT_OBJECTS)
 %.o: %.c $(LIBJQ_NAME) $(JQERLMODSRC) $(RDSSRC) $(PORT_SOURCES)
 	$(COMPILE_C) $(OUTPUT_OPTION) $<
 
+check_jqc_version:
+	( cd libs/jqc && \
+	  [ `git rev-parse --verify HEAD` = '$(JQSRC_VERSION)' ] || (cd .. && rm -rf jqc))
+
+
 $(JQSRC):
 	git clone -b jq-1.6-emqx --single-branch "$(JQURL)" "$(JQSRC_DIR)"
-	((cd "$(JQSRC_DIR)" && git checkout 51df83ccf4808867eee79a011c71a93a121be1b6) || \
+	((cd "$(JQSRC_DIR)" && git checkout $(JQSRC_VERSION)) || \
 	     (echo "Failed to check out jq commit" && \
 	      rm -r "$(JQSRC_DIR)" && \
 	      false))
 
+check_rds_version:
+	( cd libs/c_reusable_data_structures && \
+	  [ `git rev-parse --verify HEAD` = '$(RDSSRC_VERSION)' ] || (cd .. && rm -rf c_reusable_data_structures))
+
 $(RDSSRC):
 	git clone -b master --single-branch "$(RDSURL)" "$(RDSSRC_DIR)"
-	((cd "$(RDSSRC_DIR)" && git checkout 77c7a96416065a839417e5078fce9ba9a14982dc) || \
+	((cd "$(RDSSRC_DIR)" && git checkout $(RDSSRC_VERSION)) || \
 	     (echo "Failed to check out c_reusable_data_structures commit" && \
 	      rm -r "$(RDSSRC_DIR)" && \
 	      false))

--- a/c_src/erlang_jq_port.c
+++ b/c_src/erlang_jq_port.c
@@ -271,6 +271,14 @@ error_on_write_out_0:
         return false;
     } else {
         const char* error_str = "error";
+        // We might have results in the result strings. This can happen
+        // when we get a result out from jq before an error happens
+        size_t nr_of_result_objects = String_dynarr_size(&result_strings);
+        for (size_t i = 0; i < nr_of_result_objects; i++) {
+            String result = String_dynarr_item_at(&result_strings, i);
+            erljq_free(result.string);
+        }
+        String_dynarr_destroy(&result_strings);
         if (write_packet((byte*)error_str, strlen(error_str)) <= 0) {
             goto error_on_write_out_1;
         }

--- a/c_src/port_nif_common.h
+++ b/c_src/port_nif_common.h
@@ -19,7 +19,8 @@ enum {
     JQ_ERROR_BADARG    =  3,
     JQ_ERROR_COMPILE   =  4,
     JQ_ERROR_PARSE     =  5,
-    JQ_ERROR_PROCESS   =  6
+    JQ_ERROR_PROCESS   =  6,
+    JQ_ERROR_TIMEOUT   =  7
 };
 
 extern char* err_tags[];

--- a/src/jq.app.src
+++ b/src/jq.app.src
@@ -8,7 +8,7 @@
     stdlib
    ]},
   {env,[]},
-  {modules, [jq_port, jq_port_app, jq_port_sup]},
+  {modules, [jq, jq_app, jq_port, jq_nif, jq_port_sup]},
 
   {licenses, ["Apache 2.0"]},
   {links, []}

--- a/src/jq.erl
+++ b/src/jq.erl
@@ -57,11 +57,7 @@ process_json(FilterProgram, JSONText, TimeoutMs)
                      {bad_timeout_val,
                       io_lib:format("Needs positive integer or infinity but got ~p", [TimeoutMs])}};
                 TimeoutMs ->
-                    %% Timeouts are only supported by the port implementation so
-                    %% for now we use the port implementation when a timeout is
-                    %% given, even if the user has configured the library to use
-                    %% the NIF implementation.
-                    jq_port:process_json(FilterProgram, JSONText, TimeoutMs)
+                    Mod:process_json(FilterProgram, JSONText, TimeoutMs)
             end;
         _ ->
             %% Force execution of the next clause so the inputs gets 0 terminated
@@ -97,6 +93,7 @@ implementation_module() ->
 -spec set_implementation_module('jq_port' | 'jq_nif') -> 'ok'.
 
 set_implementation_module(Module) when Module =:= 'jq_port'; Module =:= 'jq_nif' ->
+    application:set_env(jq, jq_implementation_module, Module),
     persistent_term:put(jq_implementation_module, Module),
     ok.
 
@@ -122,5 +119,5 @@ init() ->
     %% we can read its properties
     application:load(jq),
     JQImplementation =
-        application:get_env(jq, jq_implementation_module, jq_port),
+        application:get_env(jq, jq_implementation_module, jq_nif),
     set_implementation_module(JQImplementation).

--- a/src/jq_app.erl
+++ b/src/jq_app.erl
@@ -8,7 +8,7 @@
 
 -behaviour(application).
 
--export([start/2, stop/1]).
+-export([start/2, stop/1, config_change/3]).
 
 start(_StartType, _StartArgs) ->
     application:load(jq),
@@ -24,5 +24,13 @@ start(_StartType, _StartArgs) ->
 
 stop(_State) ->
     ok.
+
+
+config_change(Changed, _, _) ->
+    [case V of
+         {jq_implementation_module, Module} ->
+             jq:set_implementation_module(Module);
+         _ -> ok
+     end || V <- Changed].
 
 %% internal functions

--- a/test/address_sanitizer_setup.sh
+++ b/test/address_sanitizer_setup.sh
@@ -13,8 +13,8 @@ then
     export ERL_TOP=`pwd`
     export PATH=$ERL_TOP/bin:$PATH
     
-    # Checking out OTP-24.2.1
-    git checkout 7bf7f01683acf9b8f09bd8c7331854a9abc17f7d
+    # Checking out OTP-25.0.4
+    git checkout c028b855ee3f12c835ff3538a90ac5dbc155631b
     if [ $? != 0 ]
     then
         echo "Could not check out desired Erlang version"


### PR DESCRIPTION
This PR makes it possible to use the NIF back-end for the API provided by the `jq` module even when a timeout is given to the `jq:process_json/3` function. The timout implementation in the NIF back-end depends on a patch for the jq library that adds a flag to the `jq_state` struct. This flag can be set from another thread to cancel an ongoing jq execution. The timeouts is triggered by the Erlang function `jq_nif:timeout_resource` which is scheduled with `timer:apply_after/4`. The function `jq_nif:timeout_resource` gets a NIF resource as parameter. This NIF resource contains a reference to the `jq_state` of the jq execution that needs to be canceled.