### PR TITLE
chore: update release matrix to reflect current target platforms

### DIFF
--- a/.github/actions/macos-erlang/action.yaml
+++ b/.github/actions/macos-erlang/action.yaml
@@ -14,7 +14,7 @@ runs:
     - name: prepare
       shell: bash
       run: |
-        brew install curl zip unzip gnu-sed automake bison kerl wget
+        brew install curl zip unzip gnu-sed automake libtool bison kerl wget
         echo "$(brew --prefix bison)/bin" >> $GITHUB_PATH
         git config --global credential.helper store
 

--- a/.github/workflows/eunit.yaml
+++ b/.github/workflows/eunit.yaml
@@ -13,7 +13,7 @@ jobs:
         otp:
           - 26.1.2-1
         os:
-          - macos-12-arm64
+          - macos-14
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
@@ -35,13 +35,13 @@ jobs:
       fail-fast: false
       matrix:
         builder:
-          - 5.2-7
+          - 5.3-8
         otp:
-          - 26.1.2-1
+          - 26.2.5-2
         elixir:
           - 1.15.7
         os:
-          - ubuntu22.04
+          - ubuntu24.04
 
     container: ghcr.io/emqx/emqx-builder/${{ matrix.builder }}:${{ matrix.elixir }}-${{ matrix.otp }}-${{ matrix.os }} 
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -118,9 +118,8 @@ jobs:
           name: packages
           path: packages
       - name: Create Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
-          name: Erlang jq NIF ${{ github.ref_name }} Released
+          name: Erlang jq NIF ${{ github.event.inputs.branch_or_tag || github.ref_name }} Released
+          tag_name: ${{ github.event.inputs.branch_or_tag || github.ref_name }}
           files: "packages/*"
-          draft: false
-          prerelease: false

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,9 +22,7 @@ jobs:
           - 26.1.2-1
         os:
           - macos-13
-          - macos-13-arm64
           - macos-14
-          - macos-14-arm64
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -21,9 +21,10 @@ jobs:
           - 25.3.2-2
           - 26.1.2-1
         os:
-          - macos-11
-          - macos-12
-          - macos-12-arm64
+          - macos-13
+          - macos-13-arm64
+          - macos-14
+          - macos-14-arm64
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
@@ -55,22 +56,20 @@ jobs:
       matrix:
         builder:
           - 5.1-3:1.14.5-25.3.2-1
-          - 5.2-7:1.15.7-26.1.2-1
+          - 5.3-8:1.15.7-26.2.5-2
         arch:
           - amd64
           - arm64
         os:
+          - ubuntu24.04
           - ubuntu22.04
           - ubuntu20.04
-          - ubuntu18.04
-          - ubuntu16.04
           - debian12
           - debian11
           - debian10
           - debian9
           - amzn2
           - amzn2023
-          - el7
           - el8
           - el9
           - alpine3.15.1


### PR DESCRIPTION
Also tune release action to be able to update released assets. There's often a need to rebuild exactly the same version of code but under different set of target platforms.
