### PR TITLE
build: add -std=gnu17 for Linux/FreeBSD to fix oniguruma build

### DIFF
--- a/c_src/Makefile
+++ b/c_src/Makefile
@@ -64,14 +64,14 @@ else ifeq ($(UNAME_SYS), FreeBSD)
 	CXXFLAGS ?= $(EXTRA_C_FLAGS) -finline-functions -Wall
 	LDFLAGS += -Wl,-rpath,$$ORIGIN
 	LD_JQLIBS ?= -l:libjq.a -l:libonig.a
-	JQC_STD_FLAG ?=
+	JQC_STD_FLAG ?= -std=gnu17
 else ifeq ($(UNAME_SYS), Linux)
 	CC ?= gcc
 	CFLAGS ?= $(EXTRA_C_FLAGS) -std=c11 -finline-functions -Wall -Wno-missing-prototypes -Wno-unused-function
 	CXXFLAGS ?= $(EXTRA_C_FLAGS) -finline-functions -Wall
 	LDFLAGS += -Wl,-rpath,$$ORIGIN
 	LD_JQLIBS ?= -l:libjq.a -l:libonig.a
-	JQC_STD_FLAG ?=
+	JQC_STD_FLAG ?= -std=gnu17
 endif
 
 STDC_NO_THREAD := $(shell ./check_if_threads_header_exists.sh "$(CC)" "$(CFLAGS)" threads.h)


### PR DESCRIPTION
## Summary

Add `-std=gnu17` to `JQC_STD_FLAG` for Linux and FreeBSD, matching the existing macOS fix (`fc2e76d`).

## Problem

The bundled oniguruma (v6.9.8) uses the `ANYARGS` macro (`int (*)(void)` as a wildcard function pointer type) in `st.h`, `st.c`, and `regparse.c`. Under C23 semantics, `int f()` means `int f(void)` (zero parameters), making these function pointer casts type-incompatible. This causes compilation to fail with `-Werror=incompatible-pointer-types`.

## Root Cause

**This is NOT a GCC version issue — it's an autoconf version issue.**

Starting with autoconf 2.72, `AC_PROG_CC` probes the compiler for C23 support and automatically injects `-std=gnu23` if the compiler supports it. This means:

| GCC Version | Default std | With autoconf ≥2.72 |
|-------------|------------|---------------------|
| GCC 13 | gnu17 | **gnu23** (if supported) |
| GCC 14 | gnu17 | **gnu23** |
| GCC 15 | gnu23 | gnu23 |

So even GCC 13/14 users will hit this build failure after updating autoconf to 2.72+, because autoconf's `AC_PROG_CC` overrides the compiler's default standard.

## Fix

Set `JQC_STD_FLAG = -std=gnu17` for Linux and FreeBSD (was previously empty). This flag is passed as `CFLAGS` to jqc's `autoreconf + configure` pipeline, which propagates it to oniguruma's build. It explicitly pins the C standard to C17, preventing autoconf from escalating to C23.

The macOS path already had this fix since `fc2e76d`.

## Upstream context

- oniguruma fixed this properly in [v6.9.10](https://github.com/kkos/oniguruma/commit/5f1408d) (issue [#312](https://github.com/kkos/oniguruma/issues/312))
- The `main` branch of this repo already moved to jq-1.8 with oniguruma v6.9.10 (`c1504c5`)
- This fix is for the v0.3.x release line which is pinned to jq-1.6 + oniguruma v6.9.8