### PR TITLE
fix(pkgname): only consider version-shaped tags

### DIFF
--- a/pkgname.sh
+++ b/pkgname.sh
@@ -32,7 +32,10 @@ case "$UNAMES" in
 esac
 
 ARCH="$(uname -m)"
-VSN="${CI_RELEASE_VERSION:-$(git describe --tags --exact-match | head -1)}"
+# --match 'v[0-9]*' guards against unrelated tags (e.g. an accidental
+# 'true' tag) that happen to point at the same commit and would
+# otherwise win the lex sort and produce a bogus package URL.
+VSN="${CI_RELEASE_VERSION:-$(git describe --tags --exact-match --match 'v[0-9]*' 2>/dev/null | head -1)}"
 
 if [ -z "$VSN" ]; then
     exit 0


### PR DESCRIPTION
## Summary

`pkgname.sh` constructs the prebuilt-cache filename from `git describe --tags --exact-match | head -1`. That command returns *every* tag pointing at HEAD, sorted lexicographically — and this repo has an accidental tag literally named `true` (commit `3193c06`) that aliases the `v0.4.1` commit:

    $ git tag --points-at v0.4.1
    true
    v0.4.1
    $ git describe --tags --exact-match | head -1
    true

So the produced filename becomes `jq-true-otpNN-…tar.gz`, the GitHub release has no such asset, the download 404s, and `build.sh` falls back to the full C source build (autoreconf + configure + make on `jqc` + `oniguruma`).

This is silent — every consuming repo's CI has been paying ~30–60s of jq C compile per job since v0.4.1 was published. Asset download stats confirm: `jq-v0.4.1-otp27-ubuntu24.04-x86_64.tar.gz` has **1** download.

## Fix

Constrain `git describe` to tags shaped like `v<digit>…` via `--match 'v[0-9]*'`. The accidental `true` tag is no longer a candidate, and `v0.4.1` (or future `vX.Y.Z`) wins as intended. Stderr is redirected to `/dev/null` so the "no tag exactly matches" diagnostic doesn't pollute build logs when the dep is fetched at a non-tagged SHA.

## Verification

Reproduced inside the same builder image EMQX uses:

    $ git clone --branch=v0.4.1 --depth=1 https://github.com/emqx/jq.git
    $ docker run --rm -v $PWD/jq:/jq:ro -w /jq \
        ghcr.io/emqx/emqx-builder/6.1-4:1.18.3-27.3.4.2-8-ubuntu24.04 \
        bash -c "git config --global --add safe.directory /jq; ./pkgname.sh"
    # before: jq-true-otp27-ubuntu24.04-x86_64.tar.gz   (404)
    # after:  jq-v0.4.1-otp27-ubuntu24.04-x86_64.tar.gz (302 → asset)

## Follow-up (not in this PR)

The `true` tag should ideally be deleted from the remote, but that breaks already-cached refs in fetchers that have it. The script-side guard fixes the hot path without requiring a tag rewrite. Same fix is appropriate for the `main-0.3` branch if 0.3.x is still supported.